### PR TITLE
refactor: test that publickey=null gets deleted

### DIFF
--- a/test/app.test.js
+++ b/test/app.test.js
@@ -337,6 +337,9 @@ describe('/account/deleteRecoveryMethod', () => {
 
         let response = await request.post('/account/deleteRecoveryMethod')
             .send({ accountId, recoveryMethod: 'phrase', publicKey: null, ...signature });
+
         expect(response.status).toBe(200);
+        await account.reload();
+        expect(response.body.length).toBe(0);
     });
 });


### PR DESCRIPTION
When deleting legacy recovery methods that do not have a public key, we want to make sure that the recovery method actually gets deleted