### PR TITLE
refactor helper methods into /utils and /middleware

### DIFF
--- a/app.js
+++ b/app.js
@@ -46,11 +46,14 @@ app.use(async (ctx, next) => {
     ctx.near = await nearPromise;
     await next();
 });
+
+/********************************
+Models and Middleware
+********************************/
 const SECURITY_CODE_DIGITS = 6;
 const NEW_ACCOUNT_AMOUNT = process.env.NEW_ACCOUNT_AMOUNT;
 const password = require('secure-random-password');
 const models = require('./models');
-const { sendcode, getWalletAccessKey } = require('./middleware/2fa.js');
 const {
     sendRecoveryMessage,
     sendSecurityCode,
@@ -62,14 +65,21 @@ const {
     withPublicKey,
     checkAccountOwnership
 } = require('./middleware/account.js');
-
+const {
+    sendConfirmationCode,
+    getWalletAccessKey,
+    verifyConfirmationCode
+} = require('./middleware/2fa.js');
 /********************************
-Routes
+2FA Routes
 ********************************/
-
-router.post('/sendcode', sendcode);
+router.post('/2fa/verifyConfirmationCode', verifyConfirmationCode);
+router.post('/2fa/sendConfirmationCode', sendConfirmationCode);
 router.post('/2fa/getWalletAccessKey', getWalletAccessKey);
 
+/********************************
+Other routes
+********************************/
 router.post('/account', async ctx => {
     if (!creatorKeyJson) {
         console.warn('ACCOUNT_CREATOR_KEY is not set up, cannot create accounts.');

--- a/app.js
+++ b/app.js
@@ -1,14 +1,15 @@
-const nearAPI = require('near-api-js');
+/********************************
+Koa
+********************************/
 const Koa = require('koa');
-const app = new Koa();
-
 const body = require('koa-json-body');
 const cors = require('@koa/cors');
-
+const Router = require('koa-router');
+const app = new Koa();
+const router = new Router();
 app.use(require('koa-logger')());
 app.use(body({ limit: '500kb', fallback: true }));
 app.use(cors({ credentials: true }));
-
 // Middleware to passthrough HTTP errors from node
 app.use(async function(ctx, next) {
     try {
@@ -17,7 +18,6 @@ app.use(async function(ctx, next) {
         if (e.response) {
             ctx.throw(e.response.status, e.response.text);
         }
-
         switch (e.status) {
         case 400:
         case 403:
@@ -31,17 +31,17 @@ app.use(async function(ctx, next) {
         }
     }
 });
-
-const Router = require('koa-router');
-const router = new Router();
-
+/********************************
+NearAPI
+********************************/
+const nearAPI = require('near-api-js');
+const { parseSeedPhrase } = require('near-seed-phrase');
 const creatorKeyJson = JSON.parse(process.env.ACCOUNT_CREATOR_KEY);
 const keyStore = {
     async getKey() {
         return nearAPI.KeyPair.fromString(creatorKeyJson.secret_key || creatorKeyJson.private_key);
     }
 };
-
 const nearPromise = (async () => {
     const near = await nearAPI.connect({
         deps: { keyStore },
@@ -58,9 +58,6 @@ const SECURITY_CODE_DIGITS = 6;
 const NEW_ACCOUNT_AMOUNT = process.env.NEW_ACCOUNT_AMOUNT;
 const password = require('secure-random-password');
 const models = require('./models');
-/********************************
-Routes
-********************************/
 const { sendcode } = require('./middleware/2fa.js');
 const {
     sendRecoveryMessage,
@@ -74,30 +71,11 @@ const {
     checkAccountOwnership
 } = require('./middleware/account.js');
 
-const VALID_BLOCK_AGE = 100;
+/********************************
+Routes
+********************************/
 
-async function checkAccountOwnership(ctx, next) {
-    const { accountId, blockNumber, blockNumberSignature } = ctx.request.body;
-    if (!accountId || !blockNumber || !blockNumberSignature) {
-        ctx.throw(403, 'You must provide an accountId, blockNumber, and blockNumberSignature');
-    }
-
-    const currentBlock = (await ctx.near.connection.provider.status()).sync_info.latest_block_height;
-    const givenBlock = Number(blockNumber);
-
-    if (givenBlock <= currentBlock - VALID_BLOCK_AGE || givenBlock > currentBlock) {
-        ctx.throw(403, `You must provide a blockNumber within ${VALID_BLOCK_AGE} of the most recent block; provided: ${blockNumber}, current: ${currentBlock}`);
-    }
-
-    const nearAccount = await ctx.near.account(accountId);
-    if (!(await verifySignature(nearAccount, blockNumber, blockNumberSignature))) {
-        ctx.throw(403, `blockNumberSignature did not match a signature of blockNumber=${blockNumber} from accountId=${accountId}`);
-    }
-
-    return await next();
-}
-
-const NEW_ACCOUNT_AMOUNT = process.env.NEW_ACCOUNT_AMOUNT;
+router.post('/sendcode', sendcode);
 
 router.post('/account', async ctx => {
     const { newAccountId, newAccountPublicKey } = ctx.request.body;
@@ -105,84 +83,11 @@ router.post('/account', async ctx => {
     ctx.body = await masterAccount.createAccount(newAccountId, newAccountPublicKey, NEW_ACCOUNT_AMOUNT);
 });
 
-const password = require('secure-random-password');
-const models = require('./models');
-const FROM_PHONE = process.env.TWILIO_FROM_PHONE;
-const SECURITY_CODE_DIGITS = 6;
-
-const sendSms = async ({ to, text }) => {
-    if (process.env.NODE_ENV == 'production') {
-        const accountSid = process.env.TWILIO_ACCOUNT_SID;
-        const authToken = process.env.TWILIO_AUTH_TOKEN;
-        const client = require('twilio')(accountSid, authToken);
-        await client.messages
-            .create({
-                body: text,
-                from: FROM_PHONE,
-                to
-            });
-    } else {
-        console.log('sendSms:', { to, text });
-    }
-};
-
-const nacl = require('tweetnacl');
-const crypto = require('crypto');
-const bs58 = require('bs58');
-const verifySignature = async (nearAccount, data, signature) => {
-    try {
-        const hash = crypto.createHash('sha256').update(data).digest();
-        const accessKeys = (await nearAccount.getAccessKeys())
-            .filter(k => k.access_key.permission === 'FullAccess');
-        return accessKeys.some(it => {
-            const publicKey = it.public_key.replace('ed25519:', '');
-            return nacl.sign.detached.verify(hash, Buffer.from(signature, 'base64'), bs58.decode(publicKey));
-        });
-    } catch (e) {
-        console.error(e);
-        return false;
-    }
-};
-
-async function recoveryMethodsFor(account) {
-    if (!account) return [];
-
-    return await account.getRecoveryMethods({
-        attributes: ['createdAt', 'detail', 'kind', 'publicKey', 'securityCode']
-    }).map(method => {
-        const json = method.toJSON();
-        json.confirmed = !method.securityCode;
-        delete json.securityCode;
-        return json;
-    });
-}
-
 router.post('/account/recoveryMethods', checkAccountOwnership, async ctx => {
     const { accountId } = ctx.request.body;
     const account = await models.Account.findOne({ where: { accountId } });
     ctx.body = await recoveryMethodsFor(account);
 });
-
-async function withAccount(ctx, next) {
-    const { accountId } = ctx.request.body;
-    ctx.account = await models.Account.findOne({ where: { accountId } });
-    if (ctx.account) {
-        await next();
-        return;
-    }
-    ctx.throw(404, `Could not find account with accountId: '${accountId}'`);
-}
-
-const recoveryMethods = ['email', 'phone', 'phrase'];
-
-async function checkRecoveryMethod(ctx, next) {
-    const { kind } = ctx.request.body;
-    if (recoveryMethods.includes(kind)) {
-        await next();
-        return;
-    }
-    ctx.throw(400, `Given recoveryMethod '${kind}' invalid; must be one of: ${recoveryMethods.join(', ')}`);
-}
 
 router.post(
     '/account/deleteRecoveryMethod',
@@ -226,78 +131,6 @@ router.post(
     }
 );
 
-const sendMail = async (options) => {
-    if (process.env.NODE_ENV == 'production') {
-        const nodemailer = require('nodemailer');
-        const transport = nodemailer.createTransport({
-            host: process.env.MAIL_HOST,
-            port: process.env.MAIL_PORT,
-            auth: {
-                user: process.env.MAIL_USER,
-                pass: process.env.MAIL_PASSWORD
-            }
-        });
-        return transport.sendMail({
-            from: 'wallet@nearprotocol.com',
-            ...options
-        });
-    } else {
-        console.log('sendMail:', options);
-    }
-};
-
-const WALLET_URL = process.env.WALLET_URL;
-const sendRecoveryMessage = async ({ accountId, method, seedPhrase }) => {
-    const recoverUrl = `${WALLET_URL}/recover-with-link/${encodeURIComponent(accountId)}/${encodeURIComponent(seedPhrase)}`;
-    if (method.kind === 'phone') {
-        await sendSms({
-            text: `Your NEAR Wallet (${accountId}) recovery link is: ${recoverUrl}\nSave this message in a secure place to allow you to recover account.`,
-            to: method.detail
-        });
-    } else if (method.kind === 'email') {
-        await sendMail({
-            to: method.detail,
-            subject: `Important: Near Wallet Recovery Email for ${accountId}`,
-            text:
-`Hi ${accountId},
-
-This email contains your NEAR Wallet account recovery link.
-
-Keep this email safe, and DO NOT SHARE IT! We cannot resend this email.
-
-Click below to recover your account.
-
-${recoverUrl}
-`,
-            html:
-`<p>Hi ${accountId},</p>
-
-<p>This email contains your NEAR Wallet account recovery link.</p>
-
-<p>Keep this email safe, and DO NOT SHARE IT! We cannot resend this email.</p>
-
-<p>Click below to recover your account.</p>
-
-<a href="${recoverUrl}">Recover Account</a>
-`
-
-        });
-    } else {
-        throw new Error(`Account ${accountId} has no contact information`);
-    }
-};
-
-const { parseSeedPhrase } = require('near-seed-phrase');
-
-async function withPublicKey(ctx, next) {
-    ctx.publicKey = ctx.request.body.publicKey;
-    if (ctx.publicKey !== undefined) {
-        await next();
-        return;
-    }
-    ctx.throw(400, 'Must provide valid publicKey');
-}
-
 router.post(
     '/account/seedPhraseAdded',
     checkAccountOwnership,
@@ -309,22 +142,6 @@ router.post(
         ctx.body = await recoveryMethodsFor(account);
     }
 );
-
-const sendSecurityCode = async (securityCode, method) => {
-
-    if (method.kind === 'phone') {
-        await sendSms({
-            text: `Your NEAR Wallet security code is: ${securityCode}`,
-            to: method.detail
-        });
-    } else if (method.kind === 'email') {
-        await sendMail({
-            to: method.detail,
-            subject: `Your NEAR Wallet security code is: ${securityCode}`,
-            text: `Use this code to confirm your email address: ${securityCode}`
-        });
-    }
-};
 
 router.post('/account/initializeRecoveryMethod',
     checkAccountOwnership,
@@ -405,6 +222,9 @@ router.post('/account/sendRecoveryMessage', async ctx => {
     ctx.body = await recoveryMethodsFor(account);
 });
 
+/********************************
+Start App
+********************************/
 app
     .use(router.routes())
     .use(router.allowedMethods());

--- a/app.js
+++ b/app.js
@@ -54,6 +54,25 @@ app.use(async (ctx, next) => {
     ctx.near = await nearPromise;
     await next();
 });
+const SECURITY_CODE_DIGITS = 6;
+const NEW_ACCOUNT_AMOUNT = process.env.NEW_ACCOUNT_AMOUNT;
+const password = require('secure-random-password');
+const models = require('./models');
+/********************************
+Routes
+********************************/
+const { sendcode } = require('./middleware/2fa.js');
+const {
+    sendRecoveryMessage,
+    sendSecurityCode,
+    recoveryMethodsFor,
+    checkRecoveryMethod
+} = require('./middleware/recovery.js');
+const {
+    withAccount,
+    withPublicKey,
+    checkAccountOwnership
+} = require('./middleware/account.js');
 
 const VALID_BLOCK_AGE = 100;
 

--- a/middleware/2fa.js
+++ b/middleware/2fa.js
@@ -1,22 +1,44 @@
 
-/********************************
-1. User sends tx in body
-2. Create a code to confirm
-3. SMS them the code
-4. Send response "code sent"
+const nearAPI = require('near-api-js');
+const crypto = require('crypto');
+const nacl = require('tweetnacl');
+const { getContract, creatorKeyJson } = require('../utils/near')
 
-Try this from the wallet side and make sure it works end to end
-********************************/
-
-const { sendSms } = require('./../utils/sms');
-
-console.log(sendSms);
-
+// placeholder
 const sendcode = async ctx => {
     const { tx } = ctx.request.body;
     ctx.body = { tx };
 };
 
+// generates a deterministic key based on the accountId
+const getDetermKey = async (accountId) => {
+    const hash = crypto.createHash('sha256').update(accountId + creatorKeyJson.private_key).digest();
+    const keyPair = nacl.sign.keyPair.fromSeed(hash)//nacl.sign.keyPair.fromSecretKey(hash)
+    return {
+        publicKey: `ed25519:${nearAPI.utils.serialize.base_encode(keyPair.publicKey)}`,
+        secretKey: nearAPI.utils.serialize.base_encode(keyPair.secretKey)
+    }
+}
+
+/********************************
+Multisig
+********************************/
+const viewMethods = ['get_request', 'list_request_ids', 'get_confirmations',
+    'get_num_confirmations', 'get_request_nonce',
+]
+const changeMethods = ['new', 'add_request', 'delete_request', 'confirm', 'request_expired']
+
+/********************************
+Routes
+********************************/
+const getWalletAccessKey = async (ctx) => {
+    const { accountId } = ctx.request.body
+    const keyPair = await getDetermKey(accountId)
+    ctx.body = keyPair.publicKey
+}
+
 module.exports = {
-    sendcode
+    sendcode,
+    //routes
+    getWalletAccessKey
 };

--- a/middleware/2fa.js
+++ b/middleware/2fa.js
@@ -1,0 +1,22 @@
+
+/********************************
+1. User sends tx in body
+2. Create a code to confirm
+3. SMS them the code
+4. Send response "code sent"
+
+Try this from the wallet side and make sure it works end to end
+********************************/
+
+const { sendSms } = require('./../utils/sms');
+
+console.log(sendSms);
+
+const sendcode = async ctx => {
+    const { tx } = ctx.request.body;
+    ctx.body = { tx };
+};
+
+module.exports = {
+    sendcode
+};

--- a/middleware/account.js
+++ b/middleware/account.js
@@ -1,0 +1,69 @@
+
+const models = require('./../models');
+const nacl = require('tweetnacl');
+const crypto = require('crypto');
+const bs58 = require('bs58');
+
+const verifySignature = async (nearAccount, data, signature) => {
+    try {
+        const hash = crypto.createHash('sha256').update(data).digest();
+        const accessKeys = (await nearAccount.getAccessKeys())
+            .filter(k => k.access_key.permission === 'FullAccess');
+        return accessKeys.some(it => {
+            const publicKey = it.public_key.replace('ed25519:', '');
+            return nacl.sign.detached.verify(hash, Buffer.from(signature, 'base64'), bs58.decode(publicKey));
+        });
+    } catch (e) {
+        console.error(e);
+        return false;
+    }
+};
+
+async function withPublicKey(ctx, next) {
+    ctx.publicKey = ctx.request.body.publicKey;
+    if (ctx.publicKey !== undefined) {
+        await next();
+        return;
+    }
+    ctx.throw(400, 'Must provide valid publicKey');
+}
+
+async function withAccount(ctx, next) {
+    const { accountId } = ctx.request.body;
+    ctx.account = await models.Account.findOne({ where: { accountId } });
+    if (ctx.account) {
+        await next();
+        return;
+    }
+    ctx.throw(404, `Could not find account with accountId: '${accountId}'`);
+}
+
+
+const VALID_BLOCK_AGE = 100;
+
+async function checkAccountOwnership(ctx, next) {
+    const { accountId, blockNumber, blockNumberSignature } = ctx.request.body;
+    if (!accountId || !blockNumber || !blockNumberSignature) {
+        ctx.throw(403, 'You must provide an accountId, blockNumber, and blockNumberSignature');
+    }
+
+    const currentBlock = (await ctx.near.connection.provider.status()).sync_info.latest_block_height;
+    const givenBlock = Number(blockNumber);
+
+    if (givenBlock <= currentBlock - VALID_BLOCK_AGE || givenBlock > currentBlock) {
+        ctx.throw(403, `You must provide a blockNumber within ${VALID_BLOCK_AGE} of the most recent block; provided: ${blockNumber}, current: ${currentBlock}`);
+    }
+
+    const nearAccount = await ctx.near.account(accountId);
+    if (!(await verifySignature(nearAccount, blockNumber, blockNumberSignature))) {
+        ctx.throw(403, `blockNumberSignature did not match a signature of blockNumber=${blockNumber} from accountId=${accountId}`);
+    }
+
+    return await next();
+}
+
+module.exports = {
+    withAccount,
+    withPublicKey,
+    checkAccountOwnership
+};

--- a/middleware/account.js
+++ b/middleware/account.js
@@ -8,7 +8,11 @@ const verifySignature = async (nearAccount, data, signature) => {
     try {
         const hash = crypto.createHash('sha256').update(data).digest();
         const accessKeys = (await nearAccount.getAccessKeys())
-            .filter(k => k.access_key.permission === 'FullAccess');
+            .filter(({ access_key: { permission } }) => permission === 'FullAccess' ||
+                permission.FunctionCall &&
+                    permission.FunctionCall.receiver_id === nearAccount.accountId &&
+                    permission.FunctionCall.method_names.includes('__wallet__metadata')
+            );
         return accessKeys.some(it => {
             const publicKey = it.public_key.replace('ed25519:', '');
             return nacl.sign.detached.verify(hash, Buffer.from(signature, 'base64'), bs58.decode(publicKey));

--- a/middleware/recovery.js
+++ b/middleware/recovery.js
@@ -1,0 +1,89 @@
+
+const { sendSms } = require('./../utils/sms');
+const { sendMail } = require('./../utils/email');
+
+const WALLET_URL = process.env.WALLET_URL;
+const sendRecoveryMessage = async ({ accountId, method, seedPhrase }) => {
+    const recoverUrl = `${WALLET_URL}/recover-with-link/${encodeURIComponent(accountId)}/${encodeURIComponent(seedPhrase)}`;
+    if (method.kind === 'phone') {
+        await sendSms({
+            text: `Your NEAR Wallet (${accountId}) recovery link is: ${recoverUrl}\nSave this message in a secure place to allow you to recover account.`,
+            to: method.detail
+        });
+    } else if (method.kind === 'email') {
+        await sendMail({
+            to: method.detail,
+            subject: `Important: Near Wallet Recovery Email for ${accountId}`,
+            text:
+`Hi ${accountId},
+
+This email contains your NEAR Wallet account recovery link.
+
+Keep this email safe, and DO NOT SHARE IT! We cannot resend this email.
+
+Click below to recover your account.
+
+${recoverUrl}
+`,
+            html:
+`<p>Hi ${accountId},</p>
+
+<p>This email contains your NEAR Wallet account recovery link.</p>
+
+<p>Keep this email safe, and DO NOT SHARE IT! We cannot resend this email.</p>
+
+<p>Click below to recover your account.</p>
+
+<a href="${recoverUrl}">Recover Account</a>
+`
+
+        });
+    } else {
+        throw new Error(`Account ${accountId} has no contact information`);
+    }
+};
+
+const sendSecurityCode = async (securityCode, method) => {
+
+    if (method.kind === 'phone') {
+        await sendSms({
+            text: `Your NEAR Wallet security code is: ${securityCode}`,
+            to: method.detail
+        });
+    } else if (method.kind === 'email') {
+        await sendMail({
+            to: method.detail,
+            subject: `Your NEAR Wallet security code is: ${securityCode}`,
+            text: `Use this code to confirm your email address: ${securityCode}`
+        });
+    }
+};
+
+async function recoveryMethodsFor(account) {
+    if (!account) return [];
+
+    return await account.getRecoveryMethods({
+        attributes: ['createdAt', 'detail', 'kind', 'publicKey', 'securityCode']
+    }).map(method => {
+        const json = method.toJSON();
+        json.confirmed = !method.securityCode;
+        delete json.securityCode;
+        return json;
+    });
+}
+const recoveryMethods = ['email', 'phone', 'phrase'];
+
+async function checkRecoveryMethod(ctx, next) {
+    const { kind } = ctx.request.body;
+    if (recoveryMethods.includes(kind)) {
+        await next();
+        return;
+    }
+    ctx.throw(400, `Given recoveryMethod '${kind}' invalid; must be one of: ${recoveryMethods.join(', ')}`);
+}
+module.exports = {
+    sendRecoveryMessage,
+    sendSecurityCode,
+    recoveryMethodsFor,
+    checkRecoveryMethod
+};

--- a/utils/email.js
+++ b/utils/email.js
@@ -11,7 +11,7 @@ const sendMail = async (options) => {
             }
         });
         return transport.sendMail({
-            from: 'wallet@nearprotocol.com',
+            from: process.env.WALLET_EMAIL || 'wallet@near.org',
             ...options
         });
     } else {

--- a/utils/email.js
+++ b/utils/email.js
@@ -1,0 +1,23 @@
+
+const sendMail = async (options) => {
+    if (process.env.NODE_ENV == 'production') {
+        const nodemailer = require('nodemailer');
+        const transport = nodemailer.createTransport({
+            host: process.env.MAIL_HOST,
+            port: process.env.MAIL_PORT,
+            auth: {
+                user: process.env.MAIL_USER,
+                pass: process.env.MAIL_PASSWORD
+            }
+        });
+        return transport.sendMail({
+            from: 'wallet@nearprotocol.com',
+            ...options
+        });
+    } else {
+        console.log('sendMail:', options);
+    }
+};
+module.exports = {
+    sendMail
+};

--- a/utils/near.js
+++ b/utils/near.js
@@ -1,0 +1,48 @@
+
+const nearAPI = require('near-api-js');
+
+const creatorKeyJson = (() => {
+    try {
+        return JSON.parse(process.env.ACCOUNT_CREATOR_KEY);
+    } catch (e) {
+        console.warn(`Account creation not available.\nError parsing ACCOUNT_CREATOR_KEY='${process.env.ACCOUNT_CREATOR_KEY}':`, e);
+        return null;
+    }
+})();
+const keyStore = {
+    async getKey() {
+        return nearAPI.KeyPair.fromString(creatorKeyJson.secret_key || creatorKeyJson.private_key);
+    },
+    async setKey(secretKey) {
+        return nearAPI.KeyPair.fromString(secretKey || creatorKeyJson.secret_key || creatorKeyJson.private_key);
+    }
+};
+const nearPromise = (async () => {
+    const near = await nearAPI.connect({
+        deps: { keyStore },
+        masterAccount: creatorKeyJson && creatorKeyJson.account_id,
+        nodeUrl: process.env.NODE_URL
+    });
+    return near;
+})();
+
+const getContract = async (contractName, viewMethods, changeMethods, secretKey) => {
+    if (secretKey) {
+        keyStore.setKey(secretKey)
+    }
+    const near = await nearPromise()
+	const contractAccount = new nearApi.Account(near.connection, contractName)
+    const contract = new nearAPI.Contract(contractAccount, contractName, {
+        viewMethods,
+        changeMethods,
+        sender: contractName
+    })
+    return contract
+} 
+
+module.exports = {
+    creatorKeyJson,
+    keyStore,
+    nearPromise,
+    getContract,
+}

--- a/utils/near.js
+++ b/utils/near.js
@@ -13,10 +13,8 @@ const keyStore = {
     async getKey() {
         return nearAPI.KeyPair.fromString(creatorKeyJson.secret_key || creatorKeyJson.private_key);
     },
-    async setKey(secretKey) {
-        return nearAPI.KeyPair.fromString(secretKey || creatorKeyJson.secret_key || creatorKeyJson.private_key);
-    }
 };
+
 const nearPromise = (async () => {
     const near = await nearAPI.connect({
         deps: { keyStore },
@@ -26,16 +24,25 @@ const nearPromise = (async () => {
     return near;
 })();
 
+
+
+
+
 const getContract = async (contractName, viewMethods, changeMethods, secretKey) => {
-    if (secretKey) {
-        keyStore.setKey(secretKey)
-    }
-    const near = await nearPromise()
-	const contractAccount = new nearApi.Account(near.connection, contractName)
+    const keyStore = {
+        async getKey() {
+            return nearAPI.KeyPair.fromString(secretKey);
+        },
+    };
+    const near = await nearAPI.connect({
+        deps: { keyStore },
+        masterAccount: creatorKeyJson && creatorKeyJson.account_id,
+        nodeUrl: process.env.NODE_URL
+    });
+	const contractAccount = new nearAPI.Account(near.connection, contractName)
     const contract = new nearAPI.Contract(contractAccount, contractName, {
         viewMethods,
         changeMethods,
-        sender: contractName
     })
     return contract
 } 

--- a/utils/sms.js
+++ b/utils/sms.js
@@ -1,0 +1,20 @@
+
+const FROM_PHONE = process.env.TWILIO_FROM_PHONE;
+const sendSms = async ({ to, text }) => {
+    if (process.env.NODE_ENV == 'production') {
+        const accountSid = process.env.TWILIO_ACCOUNT_SID;
+        const authToken = process.env.TWILIO_AUTH_TOKEN;
+        const client = require('twilio')(accountSid, authToken);
+        await client.messages
+            .create({
+                body: text,
+                from: FROM_PHONE,
+                to
+            });
+    } else {
+        console.log('sendSms:', { to, text });
+    }
+};
+module.exports = {
+    sendSms
+};


### PR DESCRIPTION
Cleanup and rebase of https://github.com/near/near-contract-helper/pull/152

Eager to make this repo more modular.
This PR refactors a number of methods previously used by routes defined in app.js into their own modules.
Changes to project structure:

/utils
  sms.js
  email.js
/middleware
  account.js
  recovery.js
  2fa.js (wip)