### PR TITLE
fix for sending email with on-chain request data

### DIFF
--- a/middleware/2fa.js
+++ b/middleware/2fa.js
@@ -65,13 +65,13 @@ const sendCode = async (ctx, method, twoFactorMethod, requestId = -1, accountId 
     const securityCode = password.randomPassword({ length: SECURITY_CODE_DIGITS, characters: password.digits });
     await twoFactorMethod.update({ securityCode, requestId });
     // get request data from chain
-    let request
+    let request;
     if (requestId !== -1) {
         const contract = await getContract(accountId);
         try {
             request = await contract.get_request({ request_id: parseInt(requestId) });
         } catch (e) {
-            const message = `could not find request id ${requestId} for account ${accountId}. ${e}`
+            const message = `could not find request id ${requestId} for account ${accountId}. ${e}`;
             console.warn(message);
             ctx.throw(401, message);
         }


### PR DESCRIPTION
This PR replaces data provided by client to contract helper that is emailed to 2FA method, with data from the chain pertaining to the request_id the user is seeking to confirm.

Additional multisig hash:
There is a new version of multisig that cleans up some contract storage issues and allows for unconfirmed (older than 15m) requests to be removed.

Linted. All tests passing locally.
e2e testing with wallet locally using a Render instance of this PR works fine and sends the desired email/sms.

Thanks to @abacabadabacaba for spotting this vulnerability.