### PR TITLE
Update Email Template and 2FA Messaging

### DIFF
--- a/app.js
+++ b/app.js
@@ -161,7 +161,7 @@ router.post(
     }
 );
 
-const { sendMail } = require('./utils/email');
+const { sendMail, getRecoveryHtml } = require('./utils/email');
 
 const WALLET_URL = process.env.WALLET_URL;
 const sendRecoveryMessage = async ({ accountId, method, seedPhrase }) => {
@@ -186,17 +186,7 @@ Click below to recover your account.
 
 ${recoverUrl}
 `,
-            html:
-`<p>Hi ${accountId},</p>
-
-<p>This email contains your NEAR Wallet account recovery link.</p>
-
-<p>Keep this email safe, and DO NOT SHARE IT! We cannot resend this email.</p>
-
-<p>Click below to recover your account.</p>
-
-<a href="${recoverUrl}">Recover Account</a>
-`
+            html: getRecoveryHtml(accountId, recoverUrl)
 
         });
     } else {

--- a/middleware/2fa.js
+++ b/middleware/2fa.js
@@ -18,7 +18,7 @@ const DETERM_KEY_SEED = process.env.DETERM_KEY_SEED || creatorKeyJson.private_ke
 const MULTISIG_CONTRACT_HASHES = process.env.MULTISIG_CONTRACT_HASHES ? process.env.MULTISIG_CONTRACT_HASHES.split() :['7GQStUCd8bmCK43bzD8PRh7sD2uyyeMJU5h8Rj3kXXJk','AEE3vt6S3pS2s7K6HXnZc46VyMyJcjygSMsaafFh67DF'];
 const CODE_EXPIRY = 300000;
 
-const fmtNear = (amount) => nearAPI.utils.format.formatNearAmount(amount, 4);
+const fmtNear = (amount) => nearAPI.utils.format.formatNearAmount(amount, 4) + 'Ⓝ';
 
 
 // generates a deterministic key based on the accountId

--- a/middleware/2fa.js
+++ b/middleware/2fa.js
@@ -84,7 +84,7 @@ const sendCode = async (ctx, method, twoFactorMethod, requestId = -1, accountId 
             case 'AddKey': requestDetails += `Adding key ${ a.public_key }`; break;
             case 'DeleteKey': requestDetails += `Deleting key ${ a.public_key }`; break;
             }
-            requestDetails += '\n';
+            requestDetails += '<br/>';
         });
         
     }

--- a/middleware/2fa.js
+++ b/middleware/2fa.js
@@ -71,7 +71,7 @@ const sendCode = async (ctx, method, twoFactorMethod, requestId = -1, accountId 
             ctx.throw(401, message);
         }
     }
-    method.detail = escape(method.detail)
+    method.detail = escape(method.detail);
     let isAddingFAK = false;
     let requestDetails = `Verify ${method.detail} as your 2FA method`;
     if (request) {

--- a/middleware/2fa.js
+++ b/middleware/2fa.js
@@ -74,7 +74,7 @@ const sendCode = async (ctx, method, twoFactorMethod, requestId = -1, accountId 
 NEAR Wallet security code: ${securityCode}\n\n
 Important: By entering this code, you are authorizing the following transaction:\n\n
 ${
-    JSON.stringify(request, null, 4)
+    JSON.stringify(request, null, 2)
 }
 `;
 

--- a/middleware/2fa.js
+++ b/middleware/2fa.js
@@ -9,7 +9,7 @@ const models = require('../models');
 const Sequelize = require('sequelize');
 const Op = Sequelize.Op;
 const password = require('secure-random-password');
-var escape = require('escape-html');
+const escape = require('escape-html');
 // constants
 const SECURITY_CODE_DIGITS = 6;
 const twoFactorMethods = ['2fa-email', '2fa-phone'];

--- a/middleware/2fa.js
+++ b/middleware/2fa.js
@@ -9,6 +9,7 @@ const models = require('../models');
 const Sequelize = require('sequelize');
 const Op = Sequelize.Op;
 const password = require('secure-random-password');
+var escape = require('escape-html');
 // constants
 const SECURITY_CODE_DIGITS = 6;
 const twoFactorMethods = ['2fa-email', '2fa-phone'];
@@ -19,7 +20,6 @@ const MULTISIG_CONTRACT_HASHES = process.env.MULTISIG_CONTRACT_HASHES ? process.
 const CODE_EXPIRY = 300000;
 
 const fmtNear = (amount) => nearAPI.utils.format.formatNearAmount(amount, 4) + 'Ⓝ';
-
 
 // generates a deterministic key based on the accountId
 const getKeyStore = (accountId) => ({
@@ -71,18 +71,19 @@ const sendCode = async (ctx, method, twoFactorMethod, requestId = -1, accountId 
             ctx.throw(401, message);
         }
     }
+    method.detail = escape(method.detail)
     let isAddingFAK = false;
     let requestDetails = `Verify ${method.detail} as your 2FA method`;
     if (request) {
         const { receiver_id, actions } = request;
-        requestDetails = '';
+        requestDetails = [];
         actions.forEach((a) => {
             switch (a.type) {
-            case 'FunctionCall': requestDetails += `Calling method: ${ a.method_name } with args ${ Buffer.from(a.args, 'base64').toString() } in contract: @${ receiver_id }`; break;
-            case 'Transfer': requestDetails += `Transferring ${ fmtNear(a.amount) } to: @${ receiver_id }`; break;
-            case 'Stake': requestDetails += `Staking: ${ fmtNear(a.amount) } to validator: ${ receiver_id }`; break;
-            case 'AddKey': requestDetails += `Adding key ${ a.public_key }`; break;
-            case 'DeleteKey': requestDetails += `Deleting key ${ a.public_key }`; break;
+            case 'FunctionCall': requestDetails += escape(`Calling method: ${ a.method_name } with args ${ Buffer.from(a.args, 'base64').toString() } in contract: @${ receiver_id }`); break;
+            case 'Transfer': requestDetails += escape(`Transferring ${ fmtNear(a.amount) } to: @${ receiver_id }`); break;
+            case 'Stake': requestDetails += escape(`Staking: ${ fmtNear(a.amount) } to validator: ${ receiver_id }`); break;
+            case 'AddKey': requestDetails += escape(`Adding key ${ a.public_key }`); break;
+            case 'DeleteKey': requestDetails += escape(`Deleting key ${ a.public_key }`); break;
             }
             requestDetails += '<br/>';
         });

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
   "dependencies": {
     "@koa/cors": "^3.0.0",
     "bs58": "^4.0.1",
+    "escape-html": "^1.0.3",
     "koa": "^2.13.0",
     "koa-json-body": "^5.3.0",
     "koa-logger": "^3.2.0",

--- a/utils/email.js
+++ b/utils/email.js
@@ -55,7 +55,7 @@ const get2faHtml = (isAddingFAK, securityCode, request, method) => {
             blockquote: false,
             html:
 `
-<pre>
+<pre style="font-size: 12px">
 ${
     JSON.stringify(request, null, 2)
 }

--- a/utils/email.js
+++ b/utils/email.js
@@ -20,7 +20,7 @@ const sendMail = async (options) => {
 };
 
 const getRecoveryHtml = (accountId, buttonLink) => template({
-    title: `NEAR Wallet Account Recovery`,
+    title: 'NEAR Wallet Account Recovery',
     contentPreview: `This Email contains your NEAR Wallet recovery link for the following account: ${accountId}`,
     content: [
         {
@@ -44,31 +44,12 @@ const getRecoveryHtml = (accountId, buttonLink) => template({
     buttonLink,
 });
 
-const get2faHtml = (isAddingFAK, securityCode, request, method) => {
+const get2faHtml = (isAddingFAK, securityCode, requestDetails) => {
     const content = [{
         blockquote: false,
-        html: 'This request code confirms the following transaction:'
+        html: 'Important: By entering this code, you are authorizing the following transaction:'
     }];
 
-    if (request) {
-        content.push({
-            blockquote: false,
-            html:
-`
-<pre style="font-size: 12px">
-${
-    JSON.stringify(request, null, 2)
-}
-</pre>
-`
-        });
-    } else {
-        content.push({
-            blockquote: false,
-            html: `Verify ${method.detail} as your 2FA method`
-        });
-    }
-    
     if (isAddingFAK) {
         content.push({
             blockquote: true,
@@ -80,20 +61,25 @@ ${
         });
     } else {
         content.push({
-            blockquote: true,
-            html: `Transaction request code: ${securityCode}`
+            blockquote: false,
+            html: requestDetails, 
         });
     }
 
+    content.push({
+        blockquote: true,
+        html: `Transaction request code: ${securityCode}`
+    });
+
     return template({
-        title: `NEAR Wallet Transaction Request`,
+        title: 'NEAR Wallet Transaction Request',
         contentPreview: `NEAR Wallet transaction request code: ${securityCode}`,
         content,
     });
 };
 
 const template = ({
-    title = `Sample Title`,
+    title = 'Sample Title',
     contentPreview = 'This Email is a sample',
     content = [
         {

--- a/utils/email.js
+++ b/utils/email.js
@@ -68,7 +68,7 @@ const get2faHtml = (isAddingFAK, securityCode, requestDetails) => {
 
     content.push({
         blockquote: true,
-        html: `Transaction request code: ${securityCode}`
+        html: securityCode
     });
 
     return template({
@@ -308,7 +308,7 @@ const template = ({
                     <!-- The content goes here -->
                     <td style="font-size:16px; color:#3b3b3b; line-height:24px;" class="normal-font-family md-content">
                         ${ content.map(({ blockquote, html }) => blockquote ?
-        `<p><span style="background:#F6F6F6; border-radius:5px; color:#0B70CE; display:block; font-weight:700; margin:30px 0; padding:10px 20px; text-align:center; ">${html}</span></p>` :
+        `<p><span style="background:#F6F6F6; border-radius:5px; color:#0B70CE; display:block; font-size:18px; font-weight:700; margin:30px 0; padding:10px 20px; text-align:center; ">${html}</span></p>` :
         `<p>${html}</p>`).join('\n')
 }
                     </td>

--- a/utils/email.js
+++ b/utils/email.js
@@ -128,7 +128,7 @@ const template = ({
         padding: 0;
         -webkit-font-smoothing: antialiased;
         -webkit-text-size-adjust: none;
-        background: #25272A url("https://storage.googleapis.com/near-contract-helper/email-background.png") no-repeat;
+        background: #25272A url('https://storage.googleapis.com/near-contract-helper/email-background.png') no-repeat;
         background-size: contain;
       }
   
@@ -263,7 +263,7 @@ const template = ({
     <div style="display:none; font-size:1px; color:#333; line-height:1px; max-height:0; max-width:0; opacity:0; overflow:hidden;">
       ${ contentPreview}
     </div>
-    <table class="table-container" cellpadding="0" cellspacing="0" border="0" style="margin:0 auto;">
+    <table class="table-container" cellpadding="0" cellspacing="0" border="0" style="margin:0 auto;" background="https://storage.googleapis.com/near-contract-helper/email-background.png">
       <tr>
         <td height="40"></td>
       </tr>

--- a/utils/email.js
+++ b/utils/email.js
@@ -93,7 +93,7 @@ ${
 };
 
 const template = ({
-    title: `Sample Title`,
+    title = `Sample Title`,
     contentPreview = 'This Email is a sample',
     content = [
         {

--- a/utils/email.js
+++ b/utils/email.js
@@ -258,12 +258,20 @@ const template = ({
       }
     </style>
   </head>
-  <body>
+  <body style="width: 100% !important;
+      height: 100% !important;
+      margin: 0;
+      padding: 0;
+      -webkit-font-smoothing: antialiased;
+      -webkit-text-size-adjust: none;
+      background: #25272A url('https://storage.googleapis.com/near-contract-helper/email-background.png') no-repeat;
+      background-size: contain;"
+  >
     <!-- The Email client preview part goes here -->
     <div style="display:none; font-size:1px; color:#333; line-height:1px; max-height:0; max-width:0; opacity:0; overflow:hidden;">
       ${ contentPreview}
     </div>
-    <table class="table-container" cellpadding="0" cellspacing="0" border="0" style="margin:0 auto;" background="https://storage.googleapis.com/near-contract-helper/email-background.png">
+    <table class="table-container" cellpadding="0" cellspacing="0" border="0" style="margin:0 auto;">
       <tr>
         <td height="40"></td>
       </tr>

--- a/utils/email.js
+++ b/utils/email.js
@@ -20,6 +20,7 @@ const sendMail = async (options) => {
 };
 
 const getRecoveryHtml = (accountId, buttonLink) => template({
+    title: `NEAR Wallet Account Recovery`,
     contentPreview: `This Email contains your NEAR Wallet recovery link for the following account: ${accountId}`,
     content: [
         {
@@ -83,15 +84,16 @@ ${
             html: `Transaction request code: ${securityCode}`
         });
     }
-    
 
     return template({
+        title: `NEAR Wallet Transaction Request`,
         contentPreview: `NEAR Wallet transaction request code: ${securityCode}`,
         content,
     });
 };
 
 const template = ({
+    title: `Sample Title`,
     contentPreview = 'This Email is a sample',
     content = [
         {
@@ -302,7 +304,7 @@ const template = ({
                     <td align="center" style="font-size:28px; color:#25272A; font-weight:700;"
                         class="normal-font-family">
                       <!-- The title goes here -->
-                      <span>Wallet Account Recovery</span>
+                      <span>${ title }</span>
                     </td>
                   </tr>
                   <tr>

--- a/utils/email.js
+++ b/utils/email.js
@@ -57,7 +57,7 @@ const get2faHtml = (isAddingFAK, securityCode, request, method) => {
 `
 <pre>
 ${
-    JSON.stringify(request, null, 4)
+    JSON.stringify(request, null, 2)
 }
 </pre>
 `
@@ -269,7 +269,7 @@ const template = ({
   >
     <!-- The Email client preview part goes here -->
     <div style="display:none; font-size:1px; color:#333; line-height:1px; max-height:0; max-width:0; opacity:0; overflow:hidden;">
-      ${ contentPreview}
+      ${ contentPreview }
     </div>
     <table class="table-container" cellpadding="0" cellspacing="0" border="0" style="margin:0 auto;">
       <tr>

--- a/utils/email.js
+++ b/utils/email.js
@@ -24,7 +24,7 @@ const getRecoveryHtml = (accountId, buttonLink) => template({
     content: [
         {
             blockquote: false,
-            html: `This Email contains your <a href="https://near.org/" target="_blank" title="NEAR Wallet">NEAR Wallet</a> recovery link for the following account:`
+            html: 'This Email contains your <a href="https://near.org/" target="_blank" title="NEAR Wallet">NEAR Wallet</a> recovery link for the following account:'
         },
         {
             blockquote: true,
@@ -32,28 +32,23 @@ const getRecoveryHtml = (accountId, buttonLink) => template({
         },
         {
             blockquote: false,
-            html: `Keep this Email safe, and <strong>DO NOT SHARE IT!</strong> <span style="color:#DF2626;">We cannot resend this Email.</span>`
+            html: 'Keep this Email safe, and <strong>DO NOT SHARE IT!</strong> <span style="color:#DF2626;">We cannot resend this Email.</span>'
         },
         {
             blockquote: false,
-            html: `Click below to recover your account.`
+            html: 'Click below to recover your account.'
         },
     ],
-    buttonLabel: `RECOVER ACCOUNT`,
+    buttonLabel: 'RECOVER ACCOUNT',
     buttonLink,
-})
+});
 
 const get2faHtml = (isAddingFAK, securityCode, request, method) => {
     const content = [{
         blockquote: false,
-        html: `This code confirms the following transaction:`
-    }]
-    if (isAddingFAK) {
-        content.push({
-            blockquote: true,
-            html: `<strong>Confirming this transaction will give the key full access to your account!</strong>`
-        })
-    }
+        html: 'This request code confirms the following transaction:'
+    }];
+
     if (request) {
         content.push({
             blockquote: false,
@@ -61,34 +56,51 @@ const get2faHtml = (isAddingFAK, securityCode, request, method) => {
 `
 <pre>
 ${
-JSON.stringify(request, null, 4)
+    JSON.stringify(request, null, 4)
 }
 </pre>
 `
-        })
+        });
     } else {
         content.push({
             blockquote: false,
             html: `Verify ${method.detail} as your 2FA method`
-        })
+        });
     }
+    
+    if (isAddingFAK) {
+        content.push({
+            blockquote: true,
+            html: `<strong>WARNING: entering this code will authorize full access to your NEAR account. If you did not initiate this action DO NOT continue.</strong>
+            <br />
+            This should only be done if you are adding a new seed phrase to your account. In all other cases, this is very dangerous.
+            <br />
+            If you'd like to proceed, enter the security code: ${securityCode}`
+        });
+    } else {
+        content.push({
+            blockquote: true,
+            html: `Transaction request code: ${securityCode}`
+        });
+    }
+    
 
     return template({
-        contentPreview: `NEAR Wallet security code: ${securityCode}`,
+        contentPreview: `NEAR Wallet transaction request code: ${securityCode}`,
         content,
-    })
-}
+    });
+};
 
 const template = ({
-    contentPreview = `This Email is a sample`,
+    contentPreview = 'This Email is a sample',
     content = [
         {
             blockquote: false,
-            html: `This will show up first as a <p></p> tag element.`
+            html: 'This will show up first as a <p></p> tag element.'
         },
         {
             blockquote: true,
-            html: `This will look like a blockquote with centered blue text for showing important things.`
+            html: 'This will look like a blockquote with centered blue text for showing important things.'
         },
     ],
     buttonLabel,
@@ -300,13 +312,13 @@ const template = ({
                     <!-- The content goes here -->
                     <td style="font-size:16px; color:#3b3b3b; line-height:24px;" class="normal-font-family md-content">
                         ${ content.map(({ blockquote, html }) => blockquote ?
-    `<p><span style="background:#F6F6F6; border-radius:5px; color:#0B70CE; display:block; font-weight:700; margin:30px 0; padding:10px 20px; text-align:center; ">${html}</span></p>` :
-    `<p>${html}</p>`).join('\n')
-    }
+        `<p><span style="background:#F6F6F6; border-radius:5px; color:#0B70CE; display:block; font-weight:700; margin:30px 0; padding:10px 20px; text-align:center; ">${html}</span></p>` :
+        `<p>${html}</p>`).join('\n')
+}
                     </td>
                   </tr>
                   ${ buttonLabel ?
-                    `
+        `
                     <tr>
                         <td height="20"></td>
                     </tr>
@@ -323,8 +335,8 @@ const template = ({
                         </table>
                         </td>
                     </tr>
-                    `: ``
-                  }
+                    `: ''
+}
                   <tr>
                     <td height="60"></td>
                   </tr>
@@ -369,7 +381,7 @@ const template = ({
     </table>
   </body>
 </html>
-`
+`;
 module.exports = {
     sendMail,
     getRecoveryHtml,

--- a/utils/email.js
+++ b/utils/email.js
@@ -18,6 +18,361 @@ const sendMail = async (options) => {
         console.log('sendMail:', options);
     }
 };
+
+const getRecoveryHtml = (accountId, buttonLink) => template({
+    contentPreview: `This Email contains your NEAR Wallet recovery link for the following account: ${accountId}`,
+    content: [
+        {
+            blockquote: false,
+            html: `This Email contains your <a href="https://near.org/" target="_blank" title="NEAR Wallet">NEAR Wallet</a> recovery link for the following account:`
+        },
+        {
+            blockquote: true,
+            html: accountId
+        },
+        {
+            blockquote: false,
+            html: `Keep this Email safe, and <strong>DO NOT SHARE IT!</strong> <span style="color:#DF2626;">We cannot resend this Email.</span>`
+        },
+        {
+            blockquote: false,
+            html: `Click below to recover your account.`
+        },
+    ],
+    buttonLabel: `RECOVER ACCOUNT`,
+    buttonLink,
+})
+
+const get2faHtml = (isAddingFAK, securityCode, request, method) => {
+    const content = [{
+        blockquote: false,
+        html: `This code confirms the following transaction:`
+    }]
+    if (isAddingFAK) {
+        content.push({
+            blockquote: true,
+            html: `<strong>Confirming this transaction will give the key full access to your account!</strong>`
+        })
+    }
+    if (request) {
+        content.push({
+            blockquote: false,
+            html:
+`
+<pre>
+${
+JSON.stringify(request, null, 4)
+}
+</pre>
+`
+        })
+    } else {
+        content.push({
+            blockquote: false,
+            html: `Verify ${method.detail} as your 2FA method`
+        })
+    }
+
+    return template({
+        contentPreview: `NEAR Wallet security code: ${securityCode}`,
+        content,
+    })
+}
+
+const template = ({
+    contentPreview = `This Email is a sample`,
+    content = [
+        {
+            blockquote: false,
+            html: `This will show up first as a <p></p> tag element.`
+        },
+        {
+            blockquote: true,
+            html: `This will look like a blockquote with centered blue text for showing important things.`
+        },
+    ],
+    buttonLabel,
+    buttonLink
+}) => `
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta content="width=device-width, user-scalable=yes, initial-scale=1.0" name="viewport">
+    <title>NEAR Wallet</title>
+    <style>
+      html {
+        font-family: -apple-system, system-ui, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", sans-serif;
+        -webkit-text-size-adjust: 100%;
+        -ms-text-size-adjust: 100%;
+      }
+  
+      body {
+        width: 100% !important;
+        height: 100% !important;
+        margin: 0;
+        padding: 0;
+        -webkit-font-smoothing: antialiased;
+        -webkit-text-size-adjust: none;
+        background: #25272A url("https://storage.googleapis.com/near-contract-helper/email-background.png") no-repeat;
+        background-size: contain;
+      }
+  
+      a {
+        color: #0B70CE;
+      }
+  
+      a:hover,
+      a:active {
+        opacity: .9;
+      }
+  
+      img {
+        border: 0;
+        height: auto;
+        line-height: 100%;
+        outline: none;
+        text-decoration: none;
+        -ms-interpolation-mode: bicubic;
+      }
+  
+      table {
+        border-collapse: collapse !important;
+      }
+  
+      #outlook a {
+        padding: 0; /* Force Outlook to provide a "view in browser" message */
+      }
+  
+      .ReadMsgBody {
+        width: 100%;
+      }
+  
+      .ExternalClass {
+        width: 100%; /* Force Hotmail to display emails at full width */
+      }
+  
+      .ExternalClass,
+      .ExternalClass p,
+      .ExternalClass span,
+      .ExternalClass font,
+      .ExternalClass td,
+      .ExternalClass div {
+        line-height: 100%; /* Force Hotmail to display normal line spacing */
+      }
+  
+      body, table, td, p, a, li, blockquote {
+        -webkit-text-size-adjust: 100%;
+        -ms-text-size-adjust: 100%;
+      }
+  
+      table, td {
+        mso-table-lspace: 0pt;
+        mso-table-rspace: 0pt;
+      }
+  
+      a img {
+        border: none;
+      }
+  
+      table td {
+        border-collapse: collapse;
+        padding: 0;
+      }
+  
+      /* Page style */
+      .normal-font-family {
+        font-family: -apple-system, system-ui, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", sans-serif;
+      }
+  
+      h1,
+      h2,
+      h3,
+      h4 {
+        font-weight: 700;
+        margin: 30px 0 16px;
+      }
+  
+      h1 {
+        font-size: 24px;
+      }
+  
+      h2 {
+        font-size: 20px;
+      }
+  
+      h3, h4 {
+        font-size: 16px;
+      }
+  
+      ol {
+        margin: 1em 0;
+        padding-left: 40px;
+        list-style: decimal;
+      }
+  
+      .md-content a {
+        color: #0B70CE !important;
+      }
+  
+      .table-container {
+        width: 640px;
+      }
+  
+      .main-container-sidebar-column {
+        width: 80px;
+      }
+  
+      .table-container + div > div {
+        border: none !important;
+        padding-top: 0 !important;
+      }
+  
+      /* Responsive */
+      @media only screen and (max-width: 640px) {
+        .table-container {
+          width: 96%;
+        }
+  
+        .main-container-sidebar-column {
+          width: 20px;
+        }
+
+        .email-action {
+          width: 100%;
+        }
+      }
+    </style>
+  </head>
+  <body>
+    <!-- The Email client preview part goes here -->
+    <div style="display:none; font-size:1px; color:#333; line-height:1px; max-height:0; max-width:0; opacity:0; overflow:hidden;">
+      ${ contentPreview}
+    </div>
+    <table class="table-container" cellpadding="0" cellspacing="0" border="0" style="margin:0 auto;">
+      <tr>
+        <td height="40"></td>
+      </tr>
+      <tr>
+        <td align="center">
+          <a href="https://near.org/" target="_blank" title="NEAR Protocol">
+            <img src="https://storage.googleapis.com/near-contract-helper/near-wallet-logo.png" height="40" width="140">
+          </a>
+        </td>
+      </tr>
+      <tr>
+        <td height="20"></td>
+      </tr>
+    </table>
+    <table class="table-container" cellpadding="0" cellspacing="0" border="0" style="margin:0 auto;">
+      <tr>
+        <td height="20"></td>
+      </tr>
+      <tr>
+        <td>
+          <table style="background-color:#fff; border-radius:8px;">
+            <tr>
+              <td class="main-container-sidebar-column"></td>
+              <td>
+                <table>
+                  <tr>
+                    <td height="60"></td>
+                  </tr>
+                  <tr>
+                    <td align="center">
+                      <img src="https://storage.googleapis.com/near-contract-helper/near-phone-icon.png" alt="Phone Icon" width="72">
+                    </td>
+                  </tr>
+                  <tr>
+                    <td height="20"></td>
+                  </tr>
+                  <tr>
+                    <td align="center" style="font-size:28px; color:#25272A; font-weight:700;"
+                        class="normal-font-family">
+                      <!-- The title goes here -->
+                      <span>Wallet Account Recovery</span>
+                    </td>
+                  </tr>
+                  <tr>
+                    <td height="20"></td>
+                  </tr>
+                  <tr>
+                    <!-- The content goes here -->
+                    <td style="font-size:16px; color:#3b3b3b; line-height:24px;" class="normal-font-family md-content">
+                        ${ content.map(({ blockquote, html }) => blockquote ?
+    `<p><span style="background:#F6F6F6; border-radius:5px; color:#0B70CE; display:block; font-weight:700; margin:30px 0; padding:10px 20px; text-align:center; ">${html}</span></p>` :
+    `<p>${html}</p>`).join('\n')
+    }
+                    </td>
+                  </tr>
+                  ${ buttonLabel ?
+                    `
+                    <tr>
+                        <td height="20"></td>
+                    </tr>
+                    <tr>
+                        <td>
+                        <!-- The content action button goes here -->
+                        <table class="email-action" align="center" style="border:0; height:auto; padding:0;">
+                            <tr>
+                            <td style="background:#0B70CE; border:0; border-radius:100px; color:#fff; text-align:center; width:100%;">
+                                <!-- The button goes here -->
+                                <a href="${ buttonLink}" target="_blank" style="color:#fff; display:block; font-size:14px; height:28px; letter-spacing:2px; line-height:28px; padding:8px 32px; text-decoration:none;">${buttonLabel}</a>
+                            </td>
+                            </tr>
+                        </table>
+                        </td>
+                    </tr>
+                    `: ``
+                  }
+                  <tr>
+                    <td height="60"></td>
+                  </tr>
+                </table>
+              </td>
+              <td class="main-container-sidebar-column"></td>
+            </tr>
+          </table>
+        </td>
+      </tr>
+      <tr>
+        <td height="40"></td>
+      </tr>
+      <tr>
+        <td align="center">
+          <a href="https://near.org/" target="_blank" title="NEAR Protocol">
+            <img src="https://storage.googleapis.com/near-contract-helper/near-logo.png" height="40" width="133">
+          </a>
+        </td>
+      </tr>
+      <tr>
+        <td height="40"></td>
+      </tr>
+      <tr>
+        <td align="center" style="font-size: 14px;color:#A7A9AA;">
+          &copy; 2020 NEAR Inc. All Rights Reserved.
+        </td>
+      </tr>
+      <tr>
+        <td height="10"></td>
+      </tr>
+      <tr>
+        <td align="center">
+          <a href="https://www.iubenda.com/terms-and-conditions/44958041" title="Terms of Service" target="_blank" style="font-size: 14px;color: #A7A9AA;text-decoration: none;">Terms of Service</a>
+          <span style="color: #A7A9AA;margin: 0 4px;">|</span>
+          <a href="https://www.iubenda.com/privacy-policy/44958041" title="Privacy Policy" target="_blank" style="font-size: 14px;color: #A7A9AA;text-decoration: none;">Privacy Policy</a>
+        </td>
+      </tr>
+      <tr>
+        <td height="40"></td>
+      </tr>
+    </table>
+  </body>
+</html>
+`
 module.exports = {
-    sendMail
+    sendMail,
+    getRecoveryHtml,
+    get2faHtml,
 };
+


### PR DESCRIPTION
PR updates utils/email.js to include the new template and creates 2 helper functions for recovery link emails and 2FA emails.

Messaging is according to: https://github.com/near/near-wallet/issues/751
- actions are broken out and simplified from their JSON
- args from function call are parsed from base64 and remain JSON (we won't have schema for random function calls)

Tested:
- Recovery
- Single actions
- Multiple actions (rotate keys)

Kendall has approved screenshots. Please try against your local wallet:
https://near-contract-helper-2fa.onrender.com

