### PR TITLE
Fix Account Creation Emails (now with code + recovery)

### DIFF
--- a/app.js
+++ b/app.js
@@ -241,7 +241,7 @@ const completeRecoveryInit = async ctx => {
 
     let publicKey
     if (seedPhrase) {
-        ({ publicKey } = parseSeedPhrase(recoverySeedPhrase))
+        ({ publicKey } = parseSeedPhrase(seedPhrase))
     }
 
     let [recoveryMethod] = await account.getRecoveryMethods({ where: {

--- a/app.js
+++ b/app.js
@@ -322,38 +322,6 @@ router.post('/account/validateSecurityCodeForTempAccount',
     completeRecoveryValidation
 );
 
-// router.post('/account/sendRecoveryMessage', async ctx => {
-//     const { accountId, method, seedPhrase, isNew } = ctx.request.body;
-//     // Verify that seed phrase is added to the account
-//     const { publicKey } = parseSeedPhrase(seedPhrase);
-//     const nearAccount = await ctx.near.account(accountId);
-//     const keys = await nearAccount.getAccessKeys();
-//     if (!keys.some(key => key.public_key === publicKey)) {
-//         ctx.throw(403, 'seed phrase doesn\'t match any access keys');
-//     }
-//     const account = await models.Account.findOne({ where: { accountId } });
-//     const [recoveryMethod] = await account.getRecoveryMethods({ where: {
-//         kind: method.kind,
-//         detail: method.detail
-//     }});
-//     await recoveryMethod.update({ publicKey, securityCode: null });
-//     if (isNew) {
-//         // clear all methods that may have been added by other users attempting to set up the same accountId
-//         const allRecoveryMethods = await account.getRecoveryMethods();
-//         for (const rm of allRecoveryMethods) {
-//             if (rm.publicKey !== publicKey) {
-//                 await rm.destroy();
-//             }
-//         }
-//     }
-//     await sendRecoveryMessage({
-//         accountId,
-//         method,
-//         seedPhrase
-//     });
-//     ctx.body = await recoveryMethodsFor(account);
-// });
-
 app
     .use(router.routes())
     .use(router.allowedMethods());

--- a/app.js
+++ b/app.js
@@ -233,7 +233,7 @@ const sendSecurityCode = async (securityCode, method, accountId, seedPhrase) => 
     } else if (method.kind === 'email') {
         await sendMail({
             to: method.detail, text, html,
-            subject: seedPhrase ? `Important: Near Wallet Recovery Email` : `Your NEAR Wallet security code is: ${securityCode}`,
+            subject: seedPhrase ? 'Important: Near Wallet Recovery Email' : `Your NEAR Wallet security code is: ${securityCode}`,
         });
     }
 };

--- a/app.js
+++ b/app.js
@@ -239,15 +239,22 @@ const completeRecoveryInit = async ctx => {
     const { accountId, method, seedPhrase } = ctx.request.body;
     const [account] = await models.Account.findOrCreate({ where: { accountId } });
 
+    let publicKey
+    if (seedPhrase) {
+        ({ publicKey } = parseSeedPhrase(recoverySeedPhrase))
+    }
+
     let [recoveryMethod] = await account.getRecoveryMethods({ where: {
         kind: method.kind,
-        detail: method.detail
+        detail: method.detail,
+        publicKey
     }});
 
     if (!recoveryMethod) {
         recoveryMethod = await account.createRecoveryMethod({
             kind: method.kind,
-            detail: method.detail
+            detail: method.detail,
+            publicKey
         });
     }
 

--- a/app.js
+++ b/app.js
@@ -289,6 +289,9 @@ const completeRecoveryValidation = async ctx => {
     if (!recoveryMethod) {
         ctx.throw(401);
     }
+    
+    await recoveryMethod.update({ securityCode: null });
+
     ctx.body = await recoveryMethodsFor(account);
 };
 

--- a/app.js
+++ b/app.js
@@ -219,11 +219,14 @@ router.post(
 );
 
 const sendSecurityCode = async (securityCode, method, accountId, seedPhrase) => {
-    let html, text = `Your NEAR Wallet security code is: ${securityCode}`
+    let text, html
     if (seedPhrase) {
         const recoverUrl = getRecoveryUrl(accountId, seedPhrase);
-        text += `\nEnter this code now to finish creating your account.\n\nIn the future, you can recover your account with this link: ${recoverUrl}\nSAVE this message in a secure place so you can recover your account.`
-        html = getRecoveryHtml(accountId, recoverUrl, securityCode)
+        text += `\nWelcome to NEAR Wallet!\nThis message contains your account activation code and recovery link for ${accountId}. Keep this email safe, and DO NOT SHARE IT. We cannot resend this email.\n\n1. Confirm your activation code to finish creating your account:\n${securityCode}\n\n2. In the event that you need to recover your account, click the link below, and follow the directions in NEAR Wallet.\n${recoverUrl}\n\nKeep this message safe and DO NOT SHARE IT. We cannot resend this message.`
+        html = getNewAccountEmail(accountId, recoverUrl, securityCode)
+    } else {
+        text = `Your NEAR Wallet security code is:\n${securityCode}\nEnter this code to verify your device.`
+        html = getSecurityCodeEmail(accountId, securityCode)
     }
     if (method.kind === 'phone') {
         await sendSms({ to: method.detail, text});

--- a/app.js
+++ b/app.js
@@ -278,7 +278,7 @@ router.post('/account/initializeRecoveryMethod',
     completeRecoveryInit
 );
 
-const completeRecoveryValidation = ({ isNew }) => async ctx => {
+const completeRecoveryValidation = ({ isNew } = {}) => async ctx => {
     const { accountId, method, securityCode } = ctx.request.body;
 
     if (!securityCode || isNaN(parseInt(securityCode, 10)) || securityCode.length !== 6) {

--- a/app.js
+++ b/app.js
@@ -161,10 +161,10 @@ router.post(
     }
 );
 
-const { sendMail, getRecoveryHtml } = require('./utils/email');
+const { sendMail, getRecoveryHtml, getNewAccountEmail, getSecurityCodeEmail } = require('./utils/email');
 
 const WALLET_URL = process.env.WALLET_URL;
-const getRecoveryUrl = (accountId, seedPhrase) => `${WALLET_URL}/recover-with-link/${encodeURIComponent(accountId)}/${encodeURIComponent(seedPhrase)}`
+const getRecoveryUrl = (accountId, seedPhrase) => `${WALLET_URL}/recover-with-link/${encodeURIComponent(accountId)}/${encodeURIComponent(seedPhrase)}`;
 const sendRecoveryMessage = async ({ accountId, method, seedPhrase }) => {
     const recoverUrl = getRecoveryUrl(accountId, seedPhrase);
     if (method.kind === 'phone') {
@@ -219,14 +219,14 @@ router.post(
 );
 
 const sendSecurityCode = async (securityCode, method, accountId, seedPhrase) => {
-    let text, html
+    let text, html;
     if (seedPhrase) {
         const recoverUrl = getRecoveryUrl(accountId, seedPhrase);
-        text += `\nWelcome to NEAR Wallet!\nThis message contains your account activation code and recovery link for ${accountId}. Keep this email safe, and DO NOT SHARE IT. We cannot resend this email.\n\n1. Confirm your activation code to finish creating your account:\n${securityCode}\n\n2. In the event that you need to recover your account, click the link below, and follow the directions in NEAR Wallet.\n${recoverUrl}\n\nKeep this message safe and DO NOT SHARE IT. We cannot resend this message.`
-        html = getNewAccountEmail(accountId, recoverUrl, securityCode)
+        text += `\nWelcome to NEAR Wallet!\nThis message contains your account activation code and recovery link for ${accountId}. Keep this email safe, and DO NOT SHARE IT. We cannot resend this email.\n\n1. Confirm your activation code to finish creating your account:\n${securityCode}\n\n2. In the event that you need to recover your account, click the link below, and follow the directions in NEAR Wallet.\n${recoverUrl}\n\nKeep this message safe and DO NOT SHARE IT. We cannot resend this message.`;
+        html = getNewAccountEmail(accountId, recoverUrl, securityCode);
     } else {
-        text = `Your NEAR Wallet security code is:\n${securityCode}\nEnter this code to verify your device.`
-        html = getSecurityCodeEmail(accountId, securityCode)
+        text = `Your NEAR Wallet security code is:\n${securityCode}\nEnter this code to verify your device.`;
+        html = getSecurityCodeEmail(accountId, securityCode);
     }
     if (method.kind === 'phone') {
         await sendSms({ to: method.detail, text});
@@ -242,9 +242,9 @@ const completeRecoveryInit = async ctx => {
     const { accountId, method, seedPhrase } = ctx.request.body;
     const [account] = await models.Account.findOrCreate({ where: { accountId } });
 
-    let publicKey
+    let publicKey;
     if (seedPhrase) {
-        ({ publicKey } = parseSeedPhrase(seedPhrase))
+        ({ publicKey } = parseSeedPhrase(seedPhrase));
     }
 
     let [recoveryMethod] = await account.getRecoveryMethods({ where: {

--- a/app.js
+++ b/app.js
@@ -222,7 +222,7 @@ const sendSecurityCode = async (securityCode, method, accountId, seedPhrase) => 
     let text, html;
     if (seedPhrase) {
         const recoverUrl = getRecoveryUrl(accountId, seedPhrase);
-        text += `\nWelcome to NEAR Wallet!\nThis message contains your account activation code and recovery link for ${accountId}. Keep this email safe, and DO NOT SHARE IT. We cannot resend this email.\n\n1. Confirm your activation code to finish creating your account:\n${securityCode}\n\n2. In the event that you need to recover your account, click the link below, and follow the directions in NEAR Wallet.\n${recoverUrl}\n\nKeep this message safe and DO NOT SHARE IT. We cannot resend this message.`;
+        text = `\nWelcome to NEAR Wallet!\nThis message contains your account activation code and recovery link for ${accountId}. Keep this email safe, and DO NOT SHARE IT. We cannot resend this email.\n\n1. Confirm your activation code to finish creating your account:\n${securityCode}\n\n2. In the event that you need to recover your account, click the link below, and follow the directions in NEAR Wallet.\n${recoverUrl}\n\nKeep this message safe and DO NOT SHARE IT. We cannot resend this message.`;
         html = getNewAccountEmail(accountId, recoverUrl, securityCode);
     } else {
         text = `Your NEAR Wallet security code is:\n${securityCode}\nEnter this code to verify your device.`;

--- a/app.js
+++ b/app.js
@@ -242,7 +242,7 @@ const completeRecoveryInit = async ctx => {
     const { accountId, method, seedPhrase } = ctx.request.body;
     const [account] = await models.Account.findOrCreate({ where: { accountId } });
 
-    let publicKey;
+    let publicKey = null;
     if (seedPhrase) {
         ({ publicKey } = parseSeedPhrase(seedPhrase));
     }

--- a/middleware/2fa.js
+++ b/middleware/2fa.js
@@ -16,7 +16,7 @@ const twoFactorMethods = ['2fa-email', '2fa-phone'];
 const viewMethods = ['get_request'];
 const changeMethods = ['confirm'];
 const DETERM_KEY_SEED = process.env.DETERM_KEY_SEED || creatorKeyJson.private_key;
-const MULTISIG_CONTRACT_HASHES = process.env.MULTISIG_CONTRACT_HASHES ? process.env.MULTISIG_CONTRACT_HASHES.split() :['7GQStUCd8bmCK43bzD8PRh7sD2uyyeMJU5h8Rj3kXXJk','AEE3vt6S3pS2s7K6HXnZc46VyMyJcjygSMsaafFh67DF'];
+const MULTISIG_CONTRACT_HASHES = process.env.MULTISIG_CONTRACT_HASHES ? process.env.MULTISIG_CONTRACT_HASHES.split() :['7GQStUCd8bmCK43bzD8PRh7sD2uyyeMJU5h8Rj3kXXJk','AEE3vt6S3pS2s7K6HXnZc46VyMyJcjygSMsaafFh67DF', '45gayUD7tUKFc3vvGwzoPEeFS6RjdQWu7SHGpxAJe13F'];
 const CODE_EXPIRY = 300000;
 
 const fmtNear = (amount) => nearAPI.utils.format.formatNearAmount(amount, 4) + 'Ⓝ';

--- a/middleware/2fa.js
+++ b/middleware/2fa.js
@@ -93,7 +93,7 @@ const sendCode = async (ctx, method, twoFactorMethod, requestId = -1, accountId 
     let text = `
 NEAR Wallet security code: ${securityCode}\n\n
 Important: By entering this code, you are authorizing the following transaction:\n\n
-${ requestDetails }
+${ requestDetails.replace('<br/>', '\n') }
 `;
 
     // check if adding full access key to account (AddKey with no permission)

--- a/middleware/near.js
+++ b/middleware/near.js
@@ -99,6 +99,7 @@ const withNear = async (ctx, next) => {
 };
 
 module.exports = {
+    parseSeedPhrase: require('near-seed-phrase').parseSeedPhrase,
     creatorKeyJson,
     withNear,
     checkAccountOwnership,

--- a/test/app.test.js
+++ b/test/app.test.js
@@ -122,7 +122,7 @@ describe('/account/initializeRecoveryMethodForTempAccount', () => {
 });
 
 describe('Two people send recovery methods for the same account before created', () => {
-    const method = recoveryMethods[0];
+    // const method = recoveryMethods[0];
     let savedSecurityCode = '';
     let accountId = 'doesnotexistonchain' + Date.now();
     let alice = recoveryMethods[0];

--- a/test/app.test.js
+++ b/test/app.test.js
@@ -169,32 +169,6 @@ describe('Two people send recovery methods for the same account before created',
         assert.equal(methods.length, 1);
     });
 
-    // test('send email, should only have 1 recovery method for new account now', async () => {
-    //     const response = await request.post('/account/sendRecoveryMessage')
-    //         .send({
-    //             accountId,
-    //             method,
-    //             isNew: true,
-    //             seedPhrase: SEED_PHRASE
-    //         });
-
-    //     assert.equal(response.status, 200);
-
-    //     const [, { subject, text, to }] = ctx.logs.find(log => log[0].match(/^sendMail.+/));
-    //     expect(subject).toEqual(`Important: Near Wallet Recovery Email for ${accountId}`);
-    //     expect(to).toEqual(recoveryMethods[0].detail);
-    //     expect(text).toMatch(new RegExp(`https://wallet.nearprotocol.com/recover-with-link/${accountId}/${SEED_PHRASE.replace(/ /g, '%20')}`));
-
-    //     const response2 = await request.post('/account/recoveryMethods')
-    //         .send({
-    //             accountId,
-    //             ...(await signatureFor(accountId))
-    //         });
-    //     assert.equal(response2.status, 200);
-    //     const methods = await response2.body;
-    //     assert.equal(methods.length, 1);
-    // });
-
 });
 
 describe('/account/initializeRecoveryMethod', () => {
@@ -243,55 +217,6 @@ describe('/account/initializeRecoveryMethod', () => {
 
         assert.equal(response.status, 200);
     });
-
-    // test('send email (wrong seed phrase)', async () => {
-    //     const response = await request.post('/account/sendRecoveryMessage')
-    //         .send({
-    //             accountId,
-    //             method,
-    //             seedPhrase: 'seed-phrase'
-    //         });
-
-    //     assert.equal(response.status, 403);
-    // });
-
-    // test('send email (wrong accountId)', async () => {
-    //     const response = await request.post('/account/sendRecoveryMessage')
-    //         .send({
-    //             accountId: 'wrong-id',
-    //             method,
-    //             seedPhrase: SEED_PHRASE
-    //         });
-
-    //     assert.equal(response.status, 400);
-    // });
-
-    // test('send email (wrong email)', async () => {
-    //     const response = await request.post('/account/sendRecoveryMessage')
-    //         .send({
-    //             accountId,
-    //             method: {kind: 'email', detail: 'asdada@g.com'},
-    //             seedPhrase: SEED_PHRASE
-    //         });
-
-    //     assert.equal(response.status, 400);
-    // });
-
-    // test('send email', async () => {
-    //     const response = await request.post('/account/sendRecoveryMessage')
-    //         .send({
-    //             accountId,
-    //             method,
-    //             seedPhrase: SEED_PHRASE
-    //         });
-
-    //     assert.equal(response.status, 200);
-
-    //     const [, { subject, text, to }] = ctx.logs.find(log => log[0].match(/^sendMail.+/));
-    //     expect(subject).toEqual(`Important: Near Wallet Recovery Email for ${accountId}`);
-    //     expect(to).toEqual('test@dispostable.com');
-    //     expect(text).toMatch(new RegExp(`https://wallet.nearprotocol.com/recover-with-link/${accountId}/${SEED_PHRASE.replace(/ /g, '%20')}`));
-    // });
 
 });
 

--- a/test/app.test.js
+++ b/test/app.test.js
@@ -109,6 +109,16 @@ describe('/account/initializeRecoveryMethodForTempAccount', () => {
         assert.equal(response.status, 401);
     });
 
+    test('validate security code (no code)', async () => {
+        const response = await request.post('/account/validateSecurityCodeForTempAccount')
+            .send({
+                accountId,
+                method,
+            });
+
+        assert.equal(response.status, 401);
+    });
+
     test('validate security code', async () => {
         const response = await request.post('/account/validateSecurityCodeForTempAccount')
             .send({

--- a/test/app.test.js
+++ b/test/app.test.js
@@ -148,7 +148,7 @@ describe('Two people send recovery methods for the same account before created',
         assert.equal(response.status, 200);
     });
 
-    test('validate security code alice and there are 2 methods', async () => {
+    test('validate security code alice (new account) and other methods should be removed leaving 1 recoveryMethod', async () => {
         const response = await request.post('/account/validateSecurityCodeForTempAccount')
             .send({
                 accountId,
@@ -166,34 +166,34 @@ describe('Two people send recovery methods for the same account before created',
             });
         assert.equal(response2.status, 200);
         const methods = await response2.body;
-        assert.equal(methods.length, 2);
-    });
-
-    test('send email, should only have 1 recovery method for new account now', async () => {
-        const response = await request.post('/account/sendRecoveryMessage')
-            .send({
-                accountId,
-                method,
-                isNew: true,
-                seedPhrase: SEED_PHRASE
-            });
-
-        assert.equal(response.status, 200);
-
-        const [, { subject, text, to }] = ctx.logs.find(log => log[0].match(/^sendMail.+/));
-        expect(subject).toEqual(`Important: Near Wallet Recovery Email for ${accountId}`);
-        expect(to).toEqual(recoveryMethods[0].detail);
-        expect(text).toMatch(new RegExp(`https://wallet.nearprotocol.com/recover-with-link/${accountId}/${SEED_PHRASE.replace(/ /g, '%20')}`));
-
-        const response2 = await request.post('/account/recoveryMethods')
-            .send({
-                accountId,
-                ...(await signatureFor(accountId))
-            });
-        assert.equal(response2.status, 200);
-        const methods = await response2.body;
         assert.equal(methods.length, 1);
     });
+
+    // test('send email, should only have 1 recovery method for new account now', async () => {
+    //     const response = await request.post('/account/sendRecoveryMessage')
+    //         .send({
+    //             accountId,
+    //             method,
+    //             isNew: true,
+    //             seedPhrase: SEED_PHRASE
+    //         });
+
+    //     assert.equal(response.status, 200);
+
+    //     const [, { subject, text, to }] = ctx.logs.find(log => log[0].match(/^sendMail.+/));
+    //     expect(subject).toEqual(`Important: Near Wallet Recovery Email for ${accountId}`);
+    //     expect(to).toEqual(recoveryMethods[0].detail);
+    //     expect(text).toMatch(new RegExp(`https://wallet.nearprotocol.com/recover-with-link/${accountId}/${SEED_PHRASE.replace(/ /g, '%20')}`));
+
+    //     const response2 = await request.post('/account/recoveryMethods')
+    //         .send({
+    //             accountId,
+    //             ...(await signatureFor(accountId))
+    //         });
+    //     assert.equal(response2.status, 200);
+    //     const methods = await response2.body;
+    //     assert.equal(methods.length, 1);
+    // });
 
 });
 
@@ -244,54 +244,54 @@ describe('/account/initializeRecoveryMethod', () => {
         assert.equal(response.status, 200);
     });
 
-    test('send email (wrong seed phrase)', async () => {
-        const response = await request.post('/account/sendRecoveryMessage')
-            .send({
-                accountId,
-                method,
-                seedPhrase: 'seed-phrase'
-            });
+    // test('send email (wrong seed phrase)', async () => {
+    //     const response = await request.post('/account/sendRecoveryMessage')
+    //         .send({
+    //             accountId,
+    //             method,
+    //             seedPhrase: 'seed-phrase'
+    //         });
 
-        assert.equal(response.status, 403);
-    });
+    //     assert.equal(response.status, 403);
+    // });
 
-    test('send email (wrong accountId)', async () => {
-        const response = await request.post('/account/sendRecoveryMessage')
-            .send({
-                accountId: 'wrong-id',
-                method,
-                seedPhrase: SEED_PHRASE
-            });
+    // test('send email (wrong accountId)', async () => {
+    //     const response = await request.post('/account/sendRecoveryMessage')
+    //         .send({
+    //             accountId: 'wrong-id',
+    //             method,
+    //             seedPhrase: SEED_PHRASE
+    //         });
 
-        assert.equal(response.status, 400);
-    });
+    //     assert.equal(response.status, 400);
+    // });
 
-    test('send email (wrong email)', async () => {
-        const response = await request.post('/account/sendRecoveryMessage')
-            .send({
-                accountId,
-                method: {kind: 'email', detail: 'asdada@g.com'},
-                seedPhrase: SEED_PHRASE
-            });
+    // test('send email (wrong email)', async () => {
+    //     const response = await request.post('/account/sendRecoveryMessage')
+    //         .send({
+    //             accountId,
+    //             method: {kind: 'email', detail: 'asdada@g.com'},
+    //             seedPhrase: SEED_PHRASE
+    //         });
 
-        assert.equal(response.status, 400);
-    });
+    //     assert.equal(response.status, 400);
+    // });
 
-    test('send email', async () => {
-        const response = await request.post('/account/sendRecoveryMessage')
-            .send({
-                accountId,
-                method,
-                seedPhrase: SEED_PHRASE
-            });
+    // test('send email', async () => {
+    //     const response = await request.post('/account/sendRecoveryMessage')
+    //         .send({
+    //             accountId,
+    //             method,
+    //             seedPhrase: SEED_PHRASE
+    //         });
 
-        assert.equal(response.status, 200);
+    //     assert.equal(response.status, 200);
 
-        const [, { subject, text, to }] = ctx.logs.find(log => log[0].match(/^sendMail.+/));
-        expect(subject).toEqual(`Important: Near Wallet Recovery Email for ${accountId}`);
-        expect(to).toEqual('test@dispostable.com');
-        expect(text).toMatch(new RegExp(`https://wallet.nearprotocol.com/recover-with-link/${accountId}/${SEED_PHRASE.replace(/ /g, '%20')}`));
-    });
+    //     const [, { subject, text, to }] = ctx.logs.find(log => log[0].match(/^sendMail.+/));
+    //     expect(subject).toEqual(`Important: Near Wallet Recovery Email for ${accountId}`);
+    //     expect(to).toEqual('test@dispostable.com');
+    //     expect(text).toMatch(new RegExp(`https://wallet.nearprotocol.com/recover-with-link/${accountId}/${SEED_PHRASE.replace(/ /g, '%20')}`));
+    // });
 
 });
 

--- a/utils/email.js
+++ b/utils/email.js
@@ -47,7 +47,7 @@ const getNewAccountEmail = (accountId, recoverUrl, securityCode) => template({
         html: securityCode
     },
     {
-        html: `In the event that you need to recover your account, click the link below, and follow the directions in NEAR Wallet.
+        html: `2. In the event that you need to recover your account, click the link below, and follow the directions in NEAR Wallet.
       Recover my account`
     }, {
         html: `<a href="${recoverUrl}">Recover my Account</a>`

--- a/utils/email.js
+++ b/utils/email.js
@@ -84,11 +84,11 @@ const get2faHtml = (isAddingFAK, securityCode, requestDetails) => {
     if (isAddingFAK) {
         content.push({
             blockquote: true,
-            html: `<strong>WARNING: entering this code will authorize full access to your NEAR account. If you did not initiate this action DO NOT continue.</strong>
-            <br />
-            This should only be done if you are adding a new seed phrase to your account. In all other cases, this is very dangerous.
-            <br />
-            If you'd like to proceed, enter the security code: ${securityCode}`
+            html: `<strong>WARNING: entering this code will authorize full access to your NEAR account. If you did not initiate this action DO NOT continue.</strong>`
+        }, {
+          html: `This should only be done if you are adding a new seed phrase to your account. In all other cases, this is very dangerous. `
+        }, {
+          html: `If you'd like to proceed, enter the security code: ${securityCode}`
         });
     } else {
         content.push({

--- a/utils/email.js
+++ b/utils/email.js
@@ -84,11 +84,11 @@ const get2faHtml = (isAddingFAK, securityCode, requestDetails) => {
     if (isAddingFAK) {
         content.push({
             blockquote: true,
-            html: `<strong>WARNING: entering this code will authorize full access to your NEAR account. If you did not initiate this action DO NOT continue.</strong>`
+            html: '<strong>WARNING: entering this code will authorize full access to your NEAR account. If you did not initiate this action DO NOT continue.</strong>'
         }, {
-          html: `This should only be done if you are adding a new seed phrase to your account. In all other cases, this is very dangerous. `
+            html: 'This should only be done if you are adding a new seed phrase to your account. In all other cases, this is very dangerous.'
         }, {
-          html: `If you'd like to proceed, enter the security code: ${securityCode}`
+            html: `If you'd like to proceed, enter the security code: ${securityCode}`
         });
     } else {
         content.push({

--- a/utils/email.js
+++ b/utils/email.js
@@ -1,98 +1,114 @@
 
 const sendMail = async (options) => {
-    if (process.env.NODE_ENV == 'production') {
-        const nodemailer = require('nodemailer');
-        const transport = nodemailer.createTransport({
-            host: process.env.MAIL_HOST,
-            port: process.env.MAIL_PORT,
-            auth: {
-                user: process.env.MAIL_USER,
-                pass: process.env.MAIL_PASSWORD
-            }
-        });
-        return transport.sendMail({
-            from: process.env.WALLET_EMAIL || 'wallet@near.org',
-            ...options
-        });
-    } else {
-        console.log('sendMail:', options);
-    }
+	if (process.env.NODE_ENV == 'production') {
+		const nodemailer = require('nodemailer');
+		const transport = nodemailer.createTransport({
+			host: process.env.MAIL_HOST,
+			port: process.env.MAIL_PORT,
+			auth: {
+				user: process.env.MAIL_USER,
+				pass: process.env.MAIL_PASSWORD
+			}
+		});
+		return transport.sendMail({
+			from: process.env.WALLET_EMAIL || 'wallet@near.org',
+			...options
+		});
+	} else {
+		console.log('sendMail:', options);
+	}
 };
 
-const getRecoveryHtml = (accountId, buttonLink) => template({
-    title: 'NEAR Wallet Account Recovery',
-    contentPreview: `This Email contains your NEAR Wallet recovery link for the following account: ${accountId}`,
-    content: [
-        {
-            blockquote: false,
-            html: 'This Email contains your <a href="https://near.org/" target="_blank" title="NEAR Wallet">NEAR Wallet</a> recovery link for the following account:'
-        },
-        {
-            blockquote: true,
-            html: accountId
-        },
-        {
-            blockquote: false,
-            html: 'Keep this Email safe, and <strong>DO NOT SHARE IT!</strong> <span style="color:#DF2626;">We cannot resend this Email.</span>'
-        },
-        {
-            blockquote: false,
-            html: 'Click below to recover your account.'
-        },
-    ],
-    buttonLabel: 'RECOVER ACCOUNT',
-    buttonLink,
-});
+const getRecoveryHtml = (accountId, buttonLink, securityCode) => {
+	const content = []
+	if (securityCode) {
+		content.push({
+			blockquote: false,
+			html: `Enter this code now to finish creating your account.`
+		}, {
+			blockquote: true,
+			html: securityCode
+		}, {
+			blockquote: false,
+			html: `Below is your recovery link, <strong>but</strong> confirm the above code first to finish creating your account.`
+		})
+	}
+	content.push(
+		{
+			blockquote: false,
+			html: `This Email contains your <a href="https://near.org/" target="_blank" title="NEAR Wallet">NEAR Wallet</a> recovery link for the following account:`
+		},
+		{
+			blockquote: true,
+			html: accountId
+		},
+		{
+			blockquote: false,
+			html: `Keep this Email safe, and <strong>DO NOT SHARE IT!</strong> <span style="color:#DF2626;">We cannot resend this Email.</span>`
+		},
+		{
+			blockquote: false,
+			html: `Click below to recover your account.`
+		},
+	)
+	return template({
+		title: `NEAR Wallet Account Recovery`,
+		contentPreview: `This Email contains your NEAR Wallet recovery link for the following account: ${accountId}`,
+		content,
+		buttonLabel: `RECOVER ACCOUNT`,
+		buttonLink,
+	});
+}
 
 const get2faHtml = (isAddingFAK, securityCode, requestDetails) => {
-    const content = [{
-        blockquote: false,
-        html: 'Important: By entering this code, you are authorizing the following transaction:'
-    }];
+	const content = [{
+		blockquote: false,
+		html: 'Important: By entering this code, you are authorizing the following transaction:'
+	}];
 
-    if (isAddingFAK) {
-        content.push({
-            blockquote: true,
-            html: `<strong>WARNING: entering this code will authorize full access to your NEAR account. If you did not initiate this action DO NOT continue.</strong>
+	if (isAddingFAK) {
+		content.push({
+			blockquote: true,
+			html: `<strong>WARNING: entering this code will authorize full access to your NEAR account. If you did not initiate this action DO NOT continue.</strong>
             <br />
             This should only be done if you are adding a new seed phrase to your account. In all other cases, this is very dangerous.
             <br />
             If you'd like to proceed, enter the security code: ${securityCode}`
-        });
-    } else {
-        content.push({
-            blockquote: false,
-            html: requestDetails, 
-        });
-    }
+		});
+	} else {
+		content.push({
+			blockquote: false,
+			html: requestDetails,
+		});
+	}
 
-    content.push({
-        blockquote: true,
-        html: securityCode
-    });
+	content.push({
+		blockquote: true,
+		html: securityCode
+	});
 
-    return template({
-        title: 'NEAR Wallet Transaction Request',
-        contentPreview: `NEAR Wallet transaction request code: ${securityCode}`,
-        content,
-    });
+	return template({
+		title: 'NEAR Wallet Transaction Request',
+		contentPreview: `NEAR Wallet transaction request code: ${securityCode}`,
+		content,
+	});
 };
 
 const template = ({
-    title = 'Sample Title',
-    contentPreview = 'This Email is a sample',
-    content = [
-        {
-            blockquote: false,
-            html: 'This will show up first as a <p></p> tag element.'
-        },
-        {
-            blockquote: true,
-            html: 'This will look like a blockquote with centered blue text for showing important things.'
-        },
-    ],
-    buttonLabel,
-    buttonLink
+	title = 'Sample Title',
+	contentPreview = 'This Email is a sample',
+	content = [
+		{
+			blockquote: false,
+			html: 'This will show up first as a <p></p> tag element.'
+		},
+		{
+			blockquote: true,
+			html: 'This will look like a blockquote with centered blue text for showing important things.'
+		},
+	],
+	buttonLabel,
+	buttonLink
 }) => `
 <!DOCTYPE html>
 <html lang="en">
@@ -255,7 +271,7 @@ const template = ({
   >
     <!-- The Email client preview part goes here -->
     <div style="display:none; font-size:1px; color:#333; line-height:1px; max-height:0; max-width:0; opacity:0; overflow:hidden;">
-      ${ contentPreview }
+      ${ contentPreview}
     </div>
     <table class="table-container" cellpadding="0" cellspacing="0" border="0" style="margin:0 auto;">
       <tr>
@@ -298,7 +314,7 @@ const template = ({
                     <td align="center" style="font-size:28px; color:#25272A; font-weight:700;"
                         class="normal-font-family">
                       <!-- The title goes here -->
-                      <span>${ title }</span>
+                      <span>${ title}</span>
                     </td>
                   </tr>
                   <tr>
@@ -308,13 +324,13 @@ const template = ({
                     <!-- The content goes here -->
                     <td style="font-size:16px; color:#3b3b3b; line-height:24px;" class="normal-font-family md-content">
                         ${ content.map(({ blockquote, html }) => blockquote ?
-        `<p><span style="background:#F6F6F6; border-radius:5px; color:#0B70CE; display:block; font-size:18px; font-weight:700; margin:30px 0; padding:10px 20px; text-align:center; ">${html}</span></p>` :
-        `<p>${html}</p>`).join('\n')
-}
+	`<p><span style="background:#F6F6F6; border-radius:5px; color:#0B70CE; display:block; font-size:18px; font-weight:700; margin:30px 0; padding:10px 20px; text-align:center; ">${html}</span></p>` :
+	`<p>${html}</p>`).join('\n')
+	}
                     </td>
                   </tr>
                   ${ buttonLabel ?
-        `
+		`
                     <tr>
                         <td height="20"></td>
                     </tr>
@@ -332,7 +348,7 @@ const template = ({
                         </td>
                     </tr>
                     `: ''
-}
+	}
                   <tr>
                     <td height="60"></td>
                   </tr>
@@ -379,8 +395,8 @@ const template = ({
 </html>
 `;
 module.exports = {
-    sendMail,
-    getRecoveryHtml,
-    get2faHtml,
+	sendMail,
+	getRecoveryHtml,
+	get2faHtml,
 };
 

--- a/utils/email.js
+++ b/utils/email.js
@@ -1,114 +1,127 @@
 
 const sendMail = async (options) => {
-	if (process.env.NODE_ENV == 'production') {
-		const nodemailer = require('nodemailer');
-		const transport = nodemailer.createTransport({
-			host: process.env.MAIL_HOST,
-			port: process.env.MAIL_PORT,
-			auth: {
-				user: process.env.MAIL_USER,
-				pass: process.env.MAIL_PASSWORD
-			}
-		});
-		return transport.sendMail({
-			from: process.env.WALLET_EMAIL || 'wallet@near.org',
-			...options
-		});
-	} else {
-		console.log('sendMail:', options);
-	}
+  if (process.env.NODE_ENV == 'production') {
+    const nodemailer = require('nodemailer');
+    const transport = nodemailer.createTransport({
+      host: process.env.MAIL_HOST,
+      port: process.env.MAIL_PORT,
+      auth: {
+        user: process.env.MAIL_USER,
+        pass: process.env.MAIL_PASSWORD
+      }
+    });
+    return transport.sendMail({
+      from: process.env.WALLET_EMAIL || 'wallet@near.org',
+      ...options
+    });
+  } else {
+    console.log('sendMail:', options);
+  }
 };
 
-const getRecoveryHtml = (accountId, buttonLink, securityCode) => {
-	const content = []
-	if (securityCode) {
-		content.push({
-			blockquote: false,
-			html: `Enter this code now to finish creating your account.`
-		}, {
-			blockquote: true,
-			html: securityCode
-		}, {
-			blockquote: false,
-			html: `Below is your recovery link, <strong>but</strong> confirm the above code first to finish creating your account.`
-		})
-	}
-	content.push(
-		{
-			blockquote: false,
-			html: `This Email contains your <a href="https://near.org/" target="_blank" title="NEAR Wallet">NEAR Wallet</a> recovery link for the following account:`
-		},
-		{
-			blockquote: true,
-			html: accountId
-		},
-		{
-			blockquote: false,
-			html: `Keep this Email safe, and <strong>DO NOT SHARE IT!</strong> <span style="color:#DF2626;">We cannot resend this Email.</span>`
-		},
-		{
-			blockquote: false,
-			html: `Click below to recover your account.`
-		},
-	)
-	return template({
-		title: `NEAR Wallet Account Recovery`,
-		contentPreview: `This Email contains your NEAR Wallet recovery link for the following account: ${accountId}`,
-		content,
-		buttonLabel: `RECOVER ACCOUNT`,
-		buttonLink,
-	});
-}
+const getSecurityCodeEmail = (accountId, securityCode) => template({
+  title: `Verify Your Device`,
+  contentPreview: `Your NEAR Wallet security code is: ${securityCode}`,
+  content: [{
+    html: `Your NEAR Wallet security code is:`,
+  },
+  {
+    blockquote: true,
+    html: securityCode
+  }, {
+    html: `Enter this code to verify your device.`,
+  }],
+});
+
+const getNewAccountEmail = (accountId, recoverUrl, securityCode) => template({
+  title: `Welcome to NEAR Wallet`,
+  contentPreview: `This message contains your account activation code and recovery link for ${accountId}.`,
+  content: [{
+    html: `This message contains your account activation code and recovery link for ${accountId}. Keep this Email safe, and <strong>DO NOT SHARE IT!</strong> <span style="color:#DF2626;">We cannot resend this Email.</span>`
+  },
+  {
+    html: `1. Confirm your activation code to finish creating your account:`
+  },
+  {
+    blockquote: true,
+    html: securityCode
+  },
+  {
+    html: `In the event that you need to recover your account, click the link below, and follow the directions in NEAR Wallet.
+      Recover my account`
+  }, {
+    html: `<a href="${recoverUrl}">Recover my Account</a>`
+  }],
+});
+
+const getRecoveryHtml = (accountId, buttonLink) => template({
+  title: `Welcome to NEAR Wallet`,
+  contentPreview: `This Email contains your NEAR Wallet recovery link for the following account: ${accountId}`,
+  content: [
+    {
+      html: `This Email contains your <a href="https://near.org/" target="_blank" title="NEAR Wallet">NEAR Wallet</a> recovery link for the following account:`
+    },
+    {
+      blockquote: true,
+      html: accountId
+    },
+    {
+      html: `Keep this Email safe, and <strong>DO NOT SHARE IT!</strong> <span style="color:#DF2626;">We cannot resend this Email.</span>`
+    },
+    {
+      html: `Click below to recover your account.`
+    }
+  ],
+  buttonLabel: `RECOVER ACCOUNT`,
+  buttonLink,
+})
 
 const get2faHtml = (isAddingFAK, securityCode, requestDetails) => {
-	const content = [{
-		blockquote: false,
-		html: 'Important: By entering this code, you are authorizing the following transaction:'
-	}];
+  const content = [{
+    html: 'Important: By entering this code, you are authorizing the following transaction:'
+  }];
 
-	if (isAddingFAK) {
-		content.push({
-			blockquote: true,
-			html: `<strong>WARNING: entering this code will authorize full access to your NEAR account. If you did not initiate this action DO NOT continue.</strong>
+  if (isAddingFAK) {
+    content.push({
+      blockquote: true,
+      html: `<strong>WARNING: entering this code will authorize full access to your NEAR account. If you did not initiate this action DO NOT continue.</strong>
             <br />
             This should only be done if you are adding a new seed phrase to your account. In all other cases, this is very dangerous.
             <br />
             If you'd like to proceed, enter the security code: ${securityCode}`
-		});
-	} else {
-		content.push({
-			blockquote: false,
-			html: requestDetails,
-		});
-	}
+    });
+  } else {
+    content.push({
+      html: requestDetails,
+    });
+  }
 
-	content.push({
-		blockquote: true,
-		html: securityCode
-	});
+  content.push({
+    blockquote: true,
+    html: securityCode
+  });
 
-	return template({
-		title: 'NEAR Wallet Transaction Request',
-		contentPreview: `NEAR Wallet transaction request code: ${securityCode}`,
-		content,
-	});
+  return template({
+    title: 'NEAR Wallet Transaction Request',
+    contentPreview: `NEAR Wallet transaction request code: ${securityCode}`,
+    content,
+  });
 };
 
 const template = ({
-	title = 'Sample Title',
-	contentPreview = 'This Email is a sample',
-	content = [
-		{
-			blockquote: false,
-			html: 'This will show up first as a <p></p> tag element.'
-		},
-		{
-			blockquote: true,
-			html: 'This will look like a blockquote with centered blue text for showing important things.'
-		},
-	],
-	buttonLabel,
-	buttonLink
+  title = 'Sample Title',
+  contentPreview = 'This Email is a sample',
+  content = [
+    {
+      html: 'This will show up first as a <p></p> tag element.'
+    },
+    {
+      blockquote: true,
+      html: 'This will look like a blockquote with centered blue text for showing important things.'
+    },
+  ],
+  buttonLabel,
+  buttonLink
 }) => `
 <!DOCTYPE html>
 <html lang="en">
@@ -324,13 +337,13 @@ const template = ({
                     <!-- The content goes here -->
                     <td style="font-size:16px; color:#3b3b3b; line-height:24px;" class="normal-font-family md-content">
                         ${ content.map(({ blockquote, html }) => blockquote ?
-	`<p><span style="background:#F6F6F6; border-radius:5px; color:#0B70CE; display:block; font-size:18px; font-weight:700; margin:30px 0; padding:10px 20px; text-align:center; ">${html}</span></p>` :
-	`<p>${html}</p>`).join('\n')
-	}
+  `<p><span style="background:#F6F6F6; border-radius:5px; color:#0B70CE; display:block; font-size:18px; font-weight:700; margin:30px 0; padding:10px 20px; text-align:center; ">${html}</span></p>` :
+  `<p>${html}</p>`).join('\n')
+  }
                     </td>
                   </tr>
                   ${ buttonLabel ?
-		`
+    `
                     <tr>
                         <td height="20"></td>
                     </tr>
@@ -348,7 +361,7 @@ const template = ({
                         </td>
                     </tr>
                     `: ''
-	}
+  }
                   <tr>
                     <td height="60"></td>
                   </tr>
@@ -395,8 +408,10 @@ const template = ({
 </html>
 `;
 module.exports = {
-	sendMail,
-	getRecoveryHtml,
-	get2faHtml,
+  sendMail,
+  getSecurityCodeEmail,
+  getNewAccountEmail,
+  getRecoveryHtml,
+  get2faHtml,
 };
 

--- a/utils/email.js
+++ b/utils/email.js
@@ -1,127 +1,127 @@
 
 const sendMail = async (options) => {
-  if (process.env.NODE_ENV == 'production') {
-    const nodemailer = require('nodemailer');
-    const transport = nodemailer.createTransport({
-      host: process.env.MAIL_HOST,
-      port: process.env.MAIL_PORT,
-      auth: {
-        user: process.env.MAIL_USER,
-        pass: process.env.MAIL_PASSWORD
-      }
-    });
-    return transport.sendMail({
-      from: process.env.WALLET_EMAIL || 'wallet@near.org',
-      ...options
-    });
-  } else {
-    console.log('sendMail:', options);
-  }
+    if (process.env.NODE_ENV == 'production') {
+        const nodemailer = require('nodemailer');
+        const transport = nodemailer.createTransport({
+            host: process.env.MAIL_HOST,
+            port: process.env.MAIL_PORT,
+            auth: {
+                user: process.env.MAIL_USER,
+                pass: process.env.MAIL_PASSWORD
+            }
+        });
+        return transport.sendMail({
+            from: process.env.WALLET_EMAIL || 'wallet@near.org',
+            ...options
+        });
+    } else {
+        console.log('sendMail:', options);
+    }
 };
 
 const getSecurityCodeEmail = (accountId, securityCode) => template({
-  title: `Verify Your Device`,
-  contentPreview: `Your NEAR Wallet security code is: ${securityCode}`,
-  content: [{
-    html: `Your NEAR Wallet security code is:`,
-  },
-  {
-    blockquote: true,
-    html: securityCode
-  }, {
-    html: `Enter this code to verify your device.`,
-  }],
+    title: 'Verify Your Device',
+    contentPreview: `Your NEAR Wallet security code is: ${securityCode}`,
+    content: [{
+        html: 'Your NEAR Wallet security code is:',
+    },
+    {
+        blockquote: true,
+        html: securityCode
+    }, {
+        html: 'Enter this code to verify your device.',
+    }],
 });
 
 const getNewAccountEmail = (accountId, recoverUrl, securityCode) => template({
-  title: `Welcome to NEAR Wallet`,
-  contentPreview: `This message contains your account activation code and recovery link for ${accountId}.`,
-  content: [{
-    html: `This message contains your account activation code and recovery link for ${accountId}. Keep this Email safe, and <strong>DO NOT SHARE IT!</strong> <span style="color:#DF2626;">We cannot resend this Email.</span>`
-  },
-  {
-    html: `1. Confirm your activation code to finish creating your account:`
-  },
-  {
-    blockquote: true,
-    html: securityCode
-  },
-  {
-    html: `In the event that you need to recover your account, click the link below, and follow the directions in NEAR Wallet.
+    title: 'Welcome to NEAR Wallet',
+    contentPreview: `This message contains your account activation code and recovery link for ${accountId}.`,
+    content: [{
+        html: `This message contains your account activation code and recovery link for ${accountId}. Keep this Email safe, and <strong>DO NOT SHARE IT!</strong> <span style="color:#DF2626;">We cannot resend this Email.</span>`
+    },
+    {
+        html: '1. Confirm your activation code to finish creating your account:'
+    },
+    {
+        blockquote: true,
+        html: securityCode
+    },
+    {
+        html: `In the event that you need to recover your account, click the link below, and follow the directions in NEAR Wallet.
       Recover my account`
-  }, {
-    html: `<a href="${recoverUrl}">Recover my Account</a>`
-  }],
+    }, {
+        html: `<a href="${recoverUrl}">Recover my Account</a>`
+    }],
 });
 
 const getRecoveryHtml = (accountId, buttonLink) => template({
-  title: `Welcome to NEAR Wallet`,
-  contentPreview: `This Email contains your NEAR Wallet recovery link for the following account: ${accountId}`,
-  content: [
-    {
-      html: `This Email contains your <a href="https://near.org/" target="_blank" title="NEAR Wallet">NEAR Wallet</a> recovery link for the following account:`
-    },
-    {
-      blockquote: true,
-      html: accountId
-    },
-    {
-      html: `Keep this Email safe, and <strong>DO NOT SHARE IT!</strong> <span style="color:#DF2626;">We cannot resend this Email.</span>`
-    },
-    {
-      html: `Click below to recover your account.`
-    }
-  ],
-  buttonLabel: `RECOVER ACCOUNT`,
-  buttonLink,
-})
+    title: 'Welcome to NEAR Wallet',
+    contentPreview: `This Email contains your NEAR Wallet recovery link for the following account: ${accountId}`,
+    content: [
+        {
+            html: 'This Email contains your <a href="https://near.org/" target="_blank" title="NEAR Wallet">NEAR Wallet</a> recovery link for the following account:'
+        },
+        {
+            blockquote: true,
+            html: accountId
+        },
+        {
+            html: 'Keep this Email safe, and <strong>DO NOT SHARE IT!</strong> <span style="color:#DF2626;">We cannot resend this Email.</span>'
+        },
+        {
+            html: 'Click below to recover your account.'
+        }
+    ],
+    buttonLabel: 'RECOVER ACCOUNT',
+    buttonLink,
+});
 
 const get2faHtml = (isAddingFAK, securityCode, requestDetails) => {
-  const content = [{
-    html: 'Important: By entering this code, you are authorizing the following transaction:'
-  }];
+    const content = [{
+        html: 'Important: By entering this code, you are authorizing the following transaction:'
+    }];
 
-  if (isAddingFAK) {
-    content.push({
-      blockquote: true,
-      html: `<strong>WARNING: entering this code will authorize full access to your NEAR account. If you did not initiate this action DO NOT continue.</strong>
+    if (isAddingFAK) {
+        content.push({
+            blockquote: true,
+            html: `<strong>WARNING: entering this code will authorize full access to your NEAR account. If you did not initiate this action DO NOT continue.</strong>
             <br />
             This should only be done if you are adding a new seed phrase to your account. In all other cases, this is very dangerous.
             <br />
             If you'd like to proceed, enter the security code: ${securityCode}`
-    });
-  } else {
+        });
+    } else {
+        content.push({
+            html: requestDetails,
+        });
+    }
+
     content.push({
-      html: requestDetails,
+        blockquote: true,
+        html: securityCode
     });
-  }
 
-  content.push({
-    blockquote: true,
-    html: securityCode
-  });
-
-  return template({
-    title: 'NEAR Wallet Transaction Request',
-    contentPreview: `NEAR Wallet transaction request code: ${securityCode}`,
-    content,
-  });
+    return template({
+        title: 'NEAR Wallet Transaction Request',
+        contentPreview: `NEAR Wallet transaction request code: ${securityCode}`,
+        content,
+    });
 };
 
 const template = ({
-  title = 'Sample Title',
-  contentPreview = 'This Email is a sample',
-  content = [
-    {
-      html: 'This will show up first as a <p></p> tag element.'
-    },
-    {
-      blockquote: true,
-      html: 'This will look like a blockquote with centered blue text for showing important things.'
-    },
-  ],
-  buttonLabel,
-  buttonLink
+    title = 'Sample Title',
+    contentPreview = 'This Email is a sample',
+    content = [
+        {
+            html: 'This will show up first as a <p></p> tag element.'
+        },
+        {
+            blockquote: true,
+            html: 'This will look like a blockquote with centered blue text for showing important things.'
+        },
+    ],
+    buttonLabel,
+    buttonLink
 }) => `
 <!DOCTYPE html>
 <html lang="en">
@@ -337,13 +337,13 @@ const template = ({
                     <!-- The content goes here -->
                     <td style="font-size:16px; color:#3b3b3b; line-height:24px;" class="normal-font-family md-content">
                         ${ content.map(({ blockquote, html }) => blockquote ?
-  `<p><span style="background:#F6F6F6; border-radius:5px; color:#0B70CE; display:block; font-size:18px; font-weight:700; margin:30px 0; padding:10px 20px; text-align:center; ">${html}</span></p>` :
-  `<p>${html}</p>`).join('\n')
-  }
+        `<p><span style="background:#F6F6F6; border-radius:5px; color:#0B70CE; display:block; font-size:18px; font-weight:700; margin:30px 0; padding:10px 20px; text-align:center; ">${html}</span></p>` :
+        `<p>${html}</p>`).join('\n')
+}
                     </td>
                   </tr>
                   ${ buttonLabel ?
-    `
+        `
                     <tr>
                         <td height="20"></td>
                     </tr>
@@ -361,7 +361,7 @@ const template = ({
                         </td>
                     </tr>
                     `: ''
-  }
+}
                   <tr>
                     <td height="60"></td>
                   </tr>
@@ -408,10 +408,10 @@ const template = ({
 </html>
 `;
 module.exports = {
-  sendMail,
-  getSecurityCodeEmail,
-  getNewAccountEmail,
-  getRecoveryHtml,
-  get2faHtml,
+    sendMail,
+    getSecurityCodeEmail,
+    getNewAccountEmail,
+    getRecoveryHtml,
+    get2faHtml,
 };
 


### PR DESCRIPTION
This PR includes several improvements to the account creation emails.

The text versions are also updated.

This has been tested with @Patrick1904 latest wallet fix PR for account creation: https://github.com/near/near-wallet/pull/841
 
As per @corwinharrell new design and copy:
![image](https://user-images.githubusercontent.com/321340/91238144-38a3ff00-e6f1-11ea-87ef-98d2711130d1.png)
