### PR TITLE
Fix email 2fa

### DIFF
--- a/middleware/2fa.js
+++ b/middleware/2fa.js
@@ -18,6 +18,7 @@ const changeMethods = ['confirm'];
 const DETERM_KEY_SEED = process.env.DETERM_KEY_SEED || creatorKeyJson.private_key;
 const MULTISIG_CONTRACT_HASHES = process.env.MULTISIG_CONTRACT_HASHES ? process.env.MULTISIG_CONTRACT_HASHES.split() :['7GQStUCd8bmCK43bzD8PRh7sD2uyyeMJU5h8Rj3kXXJk','AEE3vt6S3pS2s7K6HXnZc46VyMyJcjygSMsaafFh67DF', '45gayUD7tUKFc3vvGwzoPEeFS6RjdQWu7SHGpxAJe13F'];
 const CODE_EXPIRY = 300000;
+const HELPER_2FA_GAS = process.env.HELPER_2FA_GAS || '100000000000000';
 
 const fmtNear = (amount) => nearAPI.utils.format.formatNearAmount(amount, 4) + 'Ⓝ';
 
@@ -41,7 +42,7 @@ const getContract = async (accountId) => {
     const contract = new nearAPI.Contract(contractAccount, accountId, {
         viewMethods,
         changeMethods,
-    }, '100000000000000');
+    });
     return contract;
 };
 
@@ -49,7 +50,7 @@ const getContract = async (accountId) => {
 const confirmRequest = async (accountId, request_id) => {
     const contract = await getContract(accountId);
     try {
-        const res = await contract.confirm({ request_id });
+        const res = await contract.confirm({ request_id }, HELPER_2FA_GAS);
         return { success: true, res };
     } catch (e) {
         return { success: false, error: JSON.stringify(e) };

--- a/middleware/2fa.js
+++ b/middleware/2fa.js
@@ -79,7 +79,7 @@ const sendCode = async (ctx, method, twoFactorMethod, requestId = -1, accountId 
         requestDetails = [];
         actions.forEach((a) => {
             switch (a.type) {
-            case 'FunctionCall': requestDetails += escape(`Calling method: ${ a.method_name } with args ${ Buffer.from(a.args, 'base64').toString() } in contract: @${ receiver_id }`); break;
+            case 'FunctionCall': requestDetails += escape(`Calling method: ${ a.method_name } in contract: @${ receiver_id } with amount ${ a.deposit ? fmtNear(a.deposit) : '0' } and with args ${ Buffer.from(a.args, 'base64').toString() }`); break;
             case 'Transfer': requestDetails += escape(`Transferring ${ fmtNear(a.amount) } to: @${ receiver_id }`); break;
             case 'Stake': requestDetails += escape(`Staking: ${ fmtNear(a.amount) } to validator: ${ receiver_id }`); break;
             case 'AddKey': requestDetails += escape(`Adding key ${ a.public_key }`); break;

--- a/middleware/2fa.js
+++ b/middleware/2fa.js
@@ -73,7 +73,7 @@ const sendCode = async (ctx, method, twoFactorMethod, requestId = -1, accountId 
     }
     method.detail = escape(method.detail);
     let isAddingFAK = false;
-    let requestDetails = `Verify ${method.detail} as your 2FA method`;
+    let requestDetails = `Verify ${method.detail} as the 2FA method for account ${ accountId }`;
     if (request) {
         const { receiver_id, actions } = request;
         requestDetails = [];

--- a/middleware/2fa.js
+++ b/middleware/2fa.js
@@ -18,7 +18,7 @@ const changeMethods = ['confirm'];
 const DETERM_KEY_SEED = process.env.DETERM_KEY_SEED || creatorKeyJson.private_key;
 const MULTISIG_CONTRACT_HASHES = process.env.MULTISIG_CONTRACT_HASHES ? process.env.MULTISIG_CONTRACT_HASHES.split() :['7GQStUCd8bmCK43bzD8PRh7sD2uyyeMJU5h8Rj3kXXJk','AEE3vt6S3pS2s7K6HXnZc46VyMyJcjygSMsaafFh67DF', '45gayUD7tUKFc3vvGwzoPEeFS6RjdQWu7SHGpxAJe13F'];
 const CODE_EXPIRY = 300000;
-const HELPER_2FA_GAS = process.env.HELPER_2FA_GAS || '100000000000000';
+const GAS_2FA_CONFIRM = process.env.GAS_2FA_CONFIRM || '100000000000000';
 
 const fmtNear = (amount) => nearAPI.utils.format.formatNearAmount(amount, 4) + 'Ⓝ';
 
@@ -50,7 +50,7 @@ const getContract = async (accountId) => {
 const confirmRequest = async (accountId, request_id) => {
     const contract = await getContract(accountId);
     try {
-        const res = await contract.confirm({ request_id }, HELPER_2FA_GAS);
+        const res = await contract.confirm({ request_id }, GAS_2FA_CONFIRM);
         return { success: true, res };
     } catch (e) {
         return { success: false, error: JSON.stringify(e) };

--- a/middleware/2fa.js
+++ b/middleware/2fa.js
@@ -110,6 +110,8 @@ If you'd like to proceed, enter this security code: ${securityCode}
     }
 
     const html = get2faHtml(isAddingFAK, securityCode, requestDetails);
+    // require for tests
+    console.log(securityCode)
 
     if (method.kind === '2fa-phone') {
         await sendSms({

--- a/middleware/2fa.js
+++ b/middleware/2fa.js
@@ -74,6 +74,7 @@ const sendCode = async (ctx, method, twoFactorMethod, requestId = -1, accountId 
     }
     method.detail = escape(method.detail);
     let isAddingFAK = false;
+    let subject = `Confirm 2FA for ${ accountId }`;
     let requestDetails = `Verify ${method.detail} as the 2FA method for account ${ accountId }`;
     if (request) {
         const { receiver_id, actions } = request;
@@ -88,8 +89,8 @@ const sendCode = async (ctx, method, twoFactorMethod, requestId = -1, accountId 
             }
             requestDetails += '<br/>';
         });
+        subject = `Confirm Transaction from: ${ accountId }${ request ? ` to: ${ request.receiver_id }` : ''}`;
     }
-    let subject = `Confirm Transaction from: ${ accountId }${ request ? ` to: ${ request.receiver_id }` : ''}`;
     let text = `
 NEAR Wallet security code: ${securityCode}\n\n
 Important: By entering this code, you are authorizing the following transaction:\n\n
@@ -111,7 +112,7 @@ If you'd like to proceed, enter this security code: ${securityCode}
 
     const html = get2faHtml(isAddingFAK, securityCode, requestDetails);
     // require for tests
-    console.log(securityCode)
+    console.log(securityCode);
 
     if (method.kind === '2fa-phone') {
         await sendSms({

--- a/middleware/2fa.js
+++ b/middleware/2fa.js
@@ -111,8 +111,6 @@ If you'd like to proceed, enter this security code: ${securityCode}
     }
 
     const html = get2faHtml(isAddingFAK, securityCode, requestDetails);
-    // require for tests
-    console.log(securityCode);
 
     if (method.kind === '2fa-phone') {
         await sendSms({

--- a/test/2fa.test.js
+++ b/test/2fa.test.js
@@ -47,7 +47,13 @@ afterEach(() => {
     console.log = ctx.savedLog;
 });
 
-const getCodeFromLogs = () => ctx.logs.find((log) => log[0].length === 6)[0];
+const getCodeFromLogs = () => {
+    const sendLog = ctx.logs.find((log) => log[0] == 'sendSms:' || log[0] == 'sendMail:');
+    if (sendLog) {
+        const { text } = sendLog[1];
+        return /NEAR Wallet security code: (\d+)/.exec(text)[1];
+    }
+};
 
 const keyStore = new nearAPI.keyStores.InMemoryKeyStore();
 


### PR DESCRIPTION
**PR Fixes:**
- Deposit on functionCall 2FA message: https://github.com/near/near-contract-helper/issues/234
- Fix gas exceeded error for app sign confirm of function calls that require more than default gas (attach 100 Tgas vs. default 30)
- Update verify emails for 2FA to include accountId
