### PR TITLE
Revert "Release 2020-12-23"

### DIFF
--- a/middleware/indexer.js
+++ b/middleware/indexer.js
@@ -8,6 +8,7 @@ async function getPgClient() {
         });
         await client.connect();
     }
+
     return client;
 }
 
@@ -44,20 +45,9 @@ async function findStakingDeposits(ctx) {
     ctx.body = rows;
 }
 
-// TODO remove this extra client when explorer indexer is fixed to return implicit accountIds and caught up
-let clientWallet;
-async function getPgClientWallet() {
-    if (!clientWallet) {
-        clientWallet = new Client({
-            connectionString: process.env.WALLET_INDEXER_DB_CONNECTION,
-        });
-        await clientWallet.connect();
-    }
-    return clientWallet;
-}
 async function findAccountsByPublicKey(ctx) {
     const { publicKey } = ctx.params;
-    const client = await getPgClientWallet();
+    const client = await getPgClient();
     const { rows } = await client.query('SELECT DISTINCT account_id FROM access_keys WHERE public_key = $1', [publicKey]);
     ctx.body = rows.map(({ account_id }) => account_id);
 }


### PR DESCRIPTION
Reverts near/near-contract-helper#298

Currently https://helper.mainnet.near.org/publicKey/xxx/ is unresponsive.
It seems like `WALLET_INDEXER_DB_CONNECTION` variable wasn't set in the production.