### PR TITLE
add endpoint to return all staking pools

### DIFF
--- a/app.js
+++ b/app.js
@@ -85,8 +85,9 @@ router.post('/account', ratelimit({
 });
 
 
-const { findAccountsByPublicKey, findStakingDeposits, findAccountActivity } = require('./middleware/indexer');
+const { findAccountsByPublicKey, findStakingDeposits, findAccountActivity, findAllStakingPools } = require('./middleware/indexer');
 
+router.get('/stakingPools/all', findAllStakingPools);
 router.get('/publicKey/:publicKey/accounts', findAccountsByPublicKey);
 router.get('/staking-deposits/:accountId', findStakingDeposits);
 router.get('/account/:accountId/activity', findAccountActivity);

--- a/middleware/indexer.js
+++ b/middleware/indexer.js
@@ -48,7 +48,7 @@ async function findStakingDeposits(ctx) {
 async function findAllStakingPools(ctx) {
     const client = await getPgClient();
     const { rows } = await client.query(`
-        SELECT account_id FROM accounts WHERE account_id like '%poolv1%';
+        SELECT account_id FROM accounts WHERE account_id like '%.poolv1.%';
     `);
     ctx.body = rows.map(({ account_id }) => account_id);
 }

--- a/middleware/indexer.js
+++ b/middleware/indexer.js
@@ -44,6 +44,15 @@ async function findStakingDeposits(ctx) {
     ctx.body = rows;
 }
 
+
+async function findAllStakingPools(ctx) {
+    const client = await getPgClient();
+    const { rows } = await client.query(`
+        SELECT account_id FROM accounts WHERE account_id like '%poolv1%';
+    `);
+    ctx.body = rows.map(({ account_id }) => account_id);
+}
+
 async function findAccountActivity(ctx) {
     const { accountId } = ctx.params;
     let { offset, limit = 10 } = ctx.request.query;
@@ -94,6 +103,7 @@ async function findAccountsByPublicKey(ctx) {
 }
 
 module.exports = {
+    findAllStakingPools,
     findStakingDeposits,
     findAccountActivity,
     findAccountsByPublicKey


### PR DESCRIPTION
The current hack in the wallet of using 
https://github.com/near/near-wallet/blob/90476414962b2723ace331d19abe616dfa809b86/src/utils/staking.js#L295-L298
Does not work for validators that have **never** been included in the validating set e.g. new validators like "binancestaking.poolv1.near"

This endpoint that finds all accounts matching the "poolv1" subaccount naming, since they deployed a staking pool factory.

This should be used by the wallet and replace the above hack.

Endpoint:
```
router.get('/stakingPools/all', findAllStakingPools);
```