### PR TITLE
Detect likely tokens by querying for `storage_deposit` calls

### DIFF
--- a/middleware/indexer.js
+++ b/middleware/indexer.js
@@ -135,7 +135,7 @@ const findLikelyTokens = withPgClient(async (ctx) => {
         join action_receipt_actions using (receipt_id)
         where predecessor_account_id = $1
             and action_kind = 'FUNCTION_CALL'
-            and args->>'method_name' like 'ft_%'
+            and (args->>'method_name' like 'ft_%' or args->>'method_name' = 'storage_deposit')
     `;
 
     const { rows } = await client.query([mintedWithBridge, calledByUser].join(' union '), [accountId, BRIDGE_TOKEN_FACTORY_ACCOUNT_ID]);


### PR DESCRIPTION
Right now when user has withdrawn tokens from Ref Finance they don't show up if they weren't already in the list.

This can be confusing, so we can change to detect `storage_deposit` calls done by user as they basically correspond to "account creation" for given token. 
Here's example call performed by Ref Finance UI:
https://explorer.near.org/transactions/9d5VmLphGMCR5ijPCzXdZcaQnqT4BTjesb7JzGXryqsB