### PR TITLE
1659 - Funded Accounts - Update error response shape and use form-data posts for API calls

### DIFF
--- a/RecaptchaValidator/RecaptchaValidator.js
+++ b/RecaptchaValidator/RecaptchaValidator.js
@@ -72,10 +72,12 @@ class RecaptchaValidator {
             errorCodes.push(ERROR_CODES.TRANSPORT_ERROR);
         }
 
+        // Although `error-codes` is an array, currently, all possible values are mutually exclusive; use the first elem
+        const errorCode = errorCodes && errorCodes[0];
         return {
             success,
-            // Although `error-codes` is an array, currently, all possible values are mutually exclusive; use the first elem
-            error: !success && getResponseFromErrorCode(errorCodes[0])
+            error: errorCode && getResponseFromErrorCode(errorCode),
+            code: errorCode
         };
     }
 }

--- a/RecaptchaValidator/RecaptchaValidator.js
+++ b/RecaptchaValidator/RecaptchaValidator.js
@@ -61,7 +61,7 @@ class RecaptchaValidator {
             ({ body: { success, 'error-codes': errorCodes = [] } } = await this.request
                 .post(GOOGLE_RECAPTCHA_SERVICE_URL)
                 .retry(3) // Basic retry to handle truly transient issues verifying
-                .type('json')
+                .type('form')
                 .send({
                     secret: this.RECAPTCHA_SECRET,
                     response: recaptchaCode,

--- a/test/RecaptchaValidator.js
+++ b/test/RecaptchaValidator.js
@@ -66,11 +66,11 @@ describe('RecaptchaValidator', function () {
             expect(stubs.retry).calledOnceWith(3);
         });
 
-        it('should configure superagent to post JSON', async function () {
+        it('should configure superagent to post as multipart form data', async function () {
             const { instance, stubs } = getRecaptchaValidatorWithStubs();
             await instance.validateRecaptchaCode(testCode, testRemoteIp);
 
-            expect(stubs.type).calledOnceWith('json');
+            expect(stubs.type).calledOnceWith('form');
         });
     });
 


### PR DESCRIPTION
1. When we encounter a known error, we now return the body payload as JSON, with shape { success, result?, message?, code? }.  
- When `success` is `true`, `result` will contain the transaction result from the account creation, but `message` and `code` will not exist
- When `success` is `false`, `message` and `code` will contain details about what caused the failure
- If an unknown error is encountered while trying to create the account, it will be thrown via `ctx.throw` which returns just the stringified error in the body.

2. Updated reCaptcha POST behavior to use multi-part form posting, as the Google API endpoint doesn't accept JSON 🤦  :)