### PR TITLE
1659 - Add checkFundedAccountAvailable endpoint

### DIFF
--- a/app.js
+++ b/app.js
@@ -78,7 +78,7 @@ router.post('/2fa/verify', checkAccountOwnership, verifyCode);
 
 
 const ratelimit = require('koa-ratelimit');
-const { createAccount, createFundedAccount } = require('./middleware/accountCreation');
+const { createAccount, createFundedAccount, checkFundedAccountAvailable } = require('./middleware/accountCreation');
 const accountCreateRatelimitMiddleware = ratelimit({
     driver: 'memory',
     db: new Map(),
@@ -89,6 +89,7 @@ const accountCreateRatelimitMiddleware = ratelimit({
 
 router.post('/account', accountCreateRatelimitMiddleware, createAccount);
 router.post('/fundedAccount', accountCreateRatelimitMiddleware, createFundedAccount);
+router.get('/checkFundedAccountAvailable', checkFundedAccountAvailable);
 
 const { signURL } = require('./middleware/moonpay');
 router.get('/moonpay/signURL', signURL);

--- a/middleware/accountCreation.js
+++ b/middleware/accountCreation.js
@@ -32,7 +32,7 @@ const createAccount = async (ctx) => {
 
 // TODO: Adjust gas to correct amounts
 const MAX_GAS_FOR_ACCOUNT_CREATE = process.env.MAX_GAS_FOR_ACCOUNT_CREATE || '100000000000000';
-const FUNDED_ACCOUNT_BALANCE = process.env.FUNDED_ACCOUNT_BALANCE || nearAPI.utils.format.parseNearAmount('1');
+const FUNDED_ACCOUNT_BALANCE = process.env.FUNDED_ACCOUNT_BALANCE || nearAPI.utils.format.parseNearAmount('0.35');
 const FUNDED_NEW_ACCOUNT_CONTRACT_NAME = process.env.FUNDED_NEW_ACCOUNT_CONTRACT_NAME || 'near';
 const FUNDED_ACCOUNT_BALANCE_REQUIRED = (new BN(FUNDED_ACCOUNT_BALANCE).add(new BN(MAX_GAS_FOR_ACCOUNT_CREATE)));
 

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "@koa/cors": "^3.0.0",
     "@sentry/node": "^6.2.5",
     "@sentry/tracing": "^6.2.3",
+    "bn.js": "5.1.0",
     "bs58": "^4.0.1",
     "escape-html": "^1.0.3",
     "hexer": "^1.5.0",
@@ -43,6 +44,7 @@
     "twilio": "^3.60.0"
   },
   "devDependencies": {
+    "@types/bn.js": "^5.1.0",
     "@types/chai": "^4.2.16",
     "@types/chai-as-promised": "^7.1.3",
     "@types/sinon": "^9.0.11",

--- a/yarn.lock
+++ b/yarn.lock
@@ -606,6 +606,11 @@ bluebird@^3.7.2:
   resolved "https://registry.yarnpkg.com/bluebird/-/bluebird-3.7.2.tgz#9f229c15be272454ffa973ace0dbee79a1b0c36f"
   integrity sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==
 
+bn.js@5.1.0:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/bn.js/-/bn.js-5.1.0.tgz#7ef3e4af5d85a8d70d7077cb7d44bfc5cd6e6039"
+  integrity sha512-NiyuqJjtPhXcJDc8I+YeyZceSMViT39AvuFJCH3ieMcOsRvZsp2luMrGSnQaqN6HVJMvSgydLnkvw5N4xvuIoQ==
+
 bn.js@^5.0.0:
   version "5.2.0"
   resolved "https://registry.yarnpkg.com/bn.js/-/bn.js-5.2.0.tgz#358860674396c6997771a9d051fcc1b57d4ae002"


### PR DESCRIPTION
Endpoint checks the available balance in the source account used for creating funded accounts, and returns whether or not that account has enough balance to provide a funded account to the user.

This will allow us to hide the entire reCAPTCHA flow entirely in cases where the funded account has no more remaining balance, rather than the user still being forced to solve the reCAPTCHA, only to be directed to the implicit account creation screen after they have solved it.