### PR TITLE
Enable proxy ip address detection in for koa

### DIFF
--- a/app.js
+++ b/app.js
@@ -9,6 +9,9 @@ const constants = require('./constants');
 
 const { RECOVERY_METHOD_KINDS, SERVER_EVENTS } = constants;
 
+// render.com passes requests through a proxy server; we need the source IPs to be accurate for `koa-ratelimit`
+app.proxy = true;
+
 app.use(require('koa-logger')());
 app.use(body({ limit: '500kb', fallback: true }));
 app.use(cors({ credentials: true }));


### PR DESCRIPTION
Enables proxy functionality for koa server, which will fix the issue with `koa-ratelimit` not getting accurate IPs for bucketing rate limited requests.