### PR TITLE
Funded account with recovery code (lock fix)

### DIFF
--- a/app.js
+++ b/app.js
@@ -59,7 +59,7 @@ const router = new Router();
 const {
     withNear,
     checkAccountOwnership,
-    checkAccountDoesNotExist,
+    createCheckAccountDoesNotExistMiddleware,
 } = require('./middleware/near');
 
 app.use(withNear);
@@ -329,7 +329,7 @@ const completeRecoveryInit = async ctx => {
 };
 
 router.post('/account/initializeRecoveryMethodForTempAccount',
-    checkAccountDoesNotExist,
+    createCheckAccountDoesNotExistMiddleware({ source: 'body', fieldName: 'accountId' }),
     completeRecoveryInit
 );
 
@@ -384,7 +384,7 @@ router.post('/account/validateSecurityCode',
 );
 
 router.post('/account/validateSecurityCodeForTempAccount',
-    checkAccountDoesNotExist,
+    createCheckAccountDoesNotExistMiddleware({ source: 'body', fieldName: 'accountId' }),
     completeRecoveryValidation({ isNew: true })
 );
 

--- a/app.js
+++ b/app.js
@@ -103,7 +103,12 @@ const {
     clearFundedAccountNeedsDeposit,
     createFundedAccount
 } = require('./middleware/fundedAccount');
-router.post('/fundedAccount', fundedAccountCreateRatelimitMiddleware, createFundedAccount);
+router.post(
+    '/fundedAccount',
+    fundedAccountCreateRatelimitMiddleware,
+    createCheckAccountDoesNotExistMiddleware({ source: 'body', fieldName: 'newAccountId' }),
+    createFundedAccount
+);
 router.get('/checkFundedAccountAvailable', checkFundedAccountAvailable);
 router.post(
     '/fundedAccount/clearNeedsDeposit',

--- a/middleware/fundedAccount.js
+++ b/middleware/fundedAccount.js
@@ -103,7 +103,10 @@ const createFundedAccount = async (ctx) => {
             requiredUnlockBalance: NEW_FUNDED_ACCOUNT_BALANCE
         };
     } catch (e) {
-        await sequelizeAccount.destroy();
+        if(isAccountCreatedByThisCall) {
+            // Clean up SQL record if we were responsible for creating it during this API call
+            await sequelizeAccount.destroy();
+        }
 
         if (e.type === 'NotEnoughBalance') {
             setJSONErrorResponse({


### PR DESCRIPTION
Bugfix for https://github.com/near/near-wallet/issues/1752 - which is only live on staging & testnet currently.

1. Resolves a bug where any new funded accounts that were created using email or SMS recovery methods did not have their `fundedAccountNeedsDeposit` set to `true`, because those recovery methods create an account record in SQL before any post to `/fundedAccount` is done, but the existing logic in `/fundedAccount` assumed it would be the creator of the account.
2. Added an initial check to make the `/fundedAccount` route throw an error if someone hits it with an accountID that already exists, by leveraging existing middleware named `checkAccountDoesNotExist`
- Modified `checkAccountDoesNotExist` to be a factory function, `createCheckAccountDoesNotExistMiddleware()` so that we could re-use this middleware with routes that don't have the account id in `request.body.accountId` - this was needed to share this logic on `/fundedAccount`, which receives the argument as `newAccountId`.