### PR TITLE
Increase pool size to allow more concurrent clients (troubleshooting)

### DIFF
--- a/middleware/indexer.js
+++ b/middleware/indexer.js
@@ -7,6 +7,7 @@ const withPgClient = (fn) => async (ctx) => {
     if (!pool) {
         pool = new Pool({
             connectionString: process.env.INDEXER_DB_CONNECTION,
+            max: 50
         });
     }
 


### PR DESCRIPTION
Testnet appears to be having some problems with SQL concurrency against explorer; trying increasing the pool size to observe behavioural changes as a troubleshooting step