### PR TITLE
2021 07 maintenance

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,7 +1,8 @@
 version: 2
 updates:
-- package-ecosystem: npm
-  directory: "/"
-  schedule:
-    interval: daily
-  open-pull-requests-limit: 10
+    - package-ecosystem: npm
+      directory: "/"
+      schedule:
+          interval: daily
+      open-pull-requests-limit: 0
+      target-branch: "dump"

--- a/middleware/indexer.js
+++ b/middleware/indexer.js
@@ -2,11 +2,7 @@ const { Pool } = require('pg');
 
 const BRIDGE_TOKEN_FACTORY_ACCOUNT_ID = process.env.BRIDGE_TOKEN_FACTORY_ACCOUNT_ID || 'factory.bridge.near';
 
-const pool = new Pool({
-    connectionString: process.env.INDEXER_DB_CONNECTION,
-    max: 50,
-    log: (...args) => console.log(...args)
-});
+const pool = new Pool({ connectionString: process.env.INDEXER_DB_CONNECTION, });
 
 const findStakingDeposits = async (ctx) => {
     const { accountId } = ctx.params;


### PR DESCRIPTION
- Disables dependabot automatic PR creation for minor dependency version bumps, while leaving it enabled for security specific PRs
- Remove debugging changes made to the pg pool object