### PR TITLE
near-wallet/2011 - Add `stakingPools` endpoint and associated indexer query

### DIFF
--- a/app.js
+++ b/app.js
@@ -125,7 +125,8 @@ const {
     findAccountActivity,
     findReceivers,
     findLikelyTokens,
-    findLikelyNFTs
+    findLikelyNFTs,
+    findValidators,
 } = require('./middleware/indexer');
 router.get('/publicKey/:publicKey/accounts', findAccountsByPublicKey);
 router.get('/staking-deposits/:accountId', findStakingDeposits);
@@ -133,6 +134,7 @@ router.get('/account/:accountId/activity', findAccountActivity);
 router.get('/account/:accountId/callReceivers', findReceivers);
 router.get('/account/:accountId/likelyTokens', findLikelyTokens);
 router.get('/account/:accountId/likelyNFTs', findLikelyNFTs);
+router.get('/validators', findValidators);
 
 const password = require('secure-random-password');
 const models = require('./models');

--- a/app.js
+++ b/app.js
@@ -126,7 +126,7 @@ const {
     findReceivers,
     findLikelyTokens,
     findLikelyNFTs,
-    findValidators,
+    findStakingPools,
 } = require('./middleware/indexer');
 router.get('/publicKey/:publicKey/accounts', findAccountsByPublicKey);
 router.get('/staking-deposits/:accountId', findStakingDeposits);
@@ -134,7 +134,7 @@ router.get('/account/:accountId/activity', findAccountActivity);
 router.get('/account/:accountId/callReceivers', findReceivers);
 router.get('/account/:accountId/likelyTokens', findLikelyTokens);
 router.get('/account/:accountId/likelyNFTs', findLikelyNFTs);
-router.get('/validators', findValidators);
+router.get('/stakingPools', findStakingPools);
 
 const password = require('secure-random-password');
 const models = require('./models');

--- a/middleware/indexer.js
+++ b/middleware/indexer.js
@@ -145,6 +145,21 @@ const findLikelyNFTs = async (ctx) => {
     ctx.body = rows.map(({ receiver_account_id }) => receiver_account_id);
 };
 
+const WALLET_URL = process.env.WALLET_URL;
+
+async function findValidators(ctx) {
+    let validatorDetails;
+
+    // TODO: Replace with `NETWORK_ID` environment var check when we have one
+    if (WALLET_URL.includes('wallet.near.org')) {
+        ({ rows: validatorDetails } = await pool.query('SELECT account_id FROM accounts WHERE account_id LIKE \'%.poolv1.near\''));
+    } else {
+        ({ rows: validatorDetails } = await pool.query('SELECT account_id FROM accounts WHERE account_id LIKE \'%.pool.%.m0\''));
+    }
+
+    ctx.body = validatorDetails.map((v) => v.account_id);
+}
+
 module.exports = {
     findStakingDeposits,
     findAccountActivity,
@@ -152,4 +167,5 @@ module.exports = {
     findReceivers,
     findLikelyTokens,
     findLikelyNFTs,
+    findValidators
 };

--- a/middleware/indexer.js
+++ b/middleware/indexer.js
@@ -167,7 +167,7 @@ async function fetchAndCacheValidators(cache) {
     return validators;
 }
 
-async function findValidators(ctx) {
+async function findStakingPools(ctx) {
     ctx.body = validatorCache.get('validators') || await fetchAndCacheValidators(validatorCache);
 }
 
@@ -178,5 +178,5 @@ module.exports = {
     findReceivers,
     findLikelyTokens,
     findLikelyNFTs,
-    findValidators
+    findStakingPools
 };


### PR DESCRIPTION
Facilitates looking up staking pool/validators using a real-time indexer query rather than a static github user content json file (which is by now quite out of date).

Set 1 hour cache window on this list, since the list of staking pools changes rarely, to save Indexer some work.