### PR TITLE
Clean-up, code de-duplication and comments

### DIFF
--- a/app.js
+++ b/app.js
@@ -400,6 +400,7 @@ const completeRecoveryValidation = ({ isNew } = {}) => async ctx => {
     if (isNew) {
         // Implicitly reserve a funded account for the same identity to allow the user to get a funded account without receiving 2 e-mails
         try {
+            // Throws `UniqueConstraintError` due to SQL constraints if an entry with matching `identityKey` and `kind` exists, but with `claimed` = true
             const [verificationMethod, verificationMethodCreated] = await models.IdentityVerificationMethod.findOrCreate({
                 where: {
                     identityKey: method.detail,


### PR DESCRIPTION
- Comment around DB constraint causing a `UniqueConstraintError` to be thrown
- Pulled validation of verification method params into a single method rather than duplicating it in two endpoints
- Fixed incorrect error code being returned if a VerificationMethod existed has already claimed in `createIdentityVerifiedFundedAccount()`
- Made `code string` for `verificationCodeRequired` error consistent with other errors
- Centralized error codes and statusCodes that are specific to Identity Verification