### PR TITLE
Add unique email column + constraint for IdentityVerificationMethods

### DIFF
--- a/migrations/20210917010954-addUniqueIdentityKey.js
+++ b/migrations/20210917010954-addUniqueIdentityKey.js
@@ -1,0 +1,29 @@
+'use strict';
+
+const TABLE_NAME = 'IdentityVerificationMethods';
+const COLUMN_NAME = 'uniqueIdentityKey';
+
+module.exports = {
+    up: (queryInterface, Sequelize) => queryInterface
+        .sequelize
+        .transaction(transaction => queryInterface.addColumn(
+            TABLE_NAME,
+            COLUMN_NAME,
+            {
+                type: Sequelize.DataTypes.STRING,
+                allowNull: true
+            },
+            {
+                transaction,
+            }
+        )),
+
+    down: queryInterface => queryInterface
+        .sequelize
+        .transaction(transaction => queryInterface.removeColumn(
+            TABLE_NAME,
+            COLUMN_NAME,
+            { transaction }
+        )),
+
+};

--- a/migrations/20210917011012-add-IdentityVerificationMethods-unique-identityKey-constraint.js
+++ b/migrations/20210917011012-add-IdentityVerificationMethods-unique-identityKey-constraint.js
@@ -1,0 +1,34 @@
+'use strict';
+
+const TABLE_NAME = 'IdentityVerificationMethods';
+const uniqueIdentityKeyConstraintName = 'unique_constraint_identityKey_verification_method';
+
+module.exports = {
+    up: async (queryInterface) => queryInterface
+        .sequelize
+        .transaction(async (transaction) => {
+            return Promise.all([
+                queryInterface.addConstraint(
+                    TABLE_NAME,
+                    {
+                        fields: ['uniqueIdentityKey'],
+                        name: uniqueIdentityKeyConstraintName,
+                        type: 'unique',
+                    },
+                    { transaction }
+                )
+            ]);
+        }),
+
+    down: async (queryInterface) => queryInterface
+        .sequelize
+        .transaction(async (transaction) => {
+            return Promise.all([
+                queryInterface.removeConstraint(
+                    TABLE_NAME,
+                    uniqueIdentityKeyConstraintName,
+                    { transaction }
+                ),
+            ]);
+        })
+};


### PR DESCRIPTION
Add uniqueIdentityKey column to support for deduping of aliased addresses, with unique constraint to avoid any duplicates ever existing