### PR TITLE
Enable unique email

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -15,5 +15,6 @@ module.exports = {
         semi: ['error', 'always'],
         'no-console': 'off',
         'require-atomic-updates': 'off',
+        'no-useless-escape': 'off',
     },
 };

--- a/app.js
+++ b/app.js
@@ -125,7 +125,7 @@ router.post(
     clearFundedAccountNeedsDeposit
 );
 
-const { createIdentityVerificationMethod, validateEmail } = require('./middleware/identityVerificationMethod');
+const { createIdentityVerificationMethod, validateEmail, getUniqueEmail } = require('./middleware/identityVerificationMethod');
 router.post(
     '/identityVerificationMethod',
     createIdentityVerificationMethod
@@ -360,6 +360,7 @@ router.post('/account/initializeRecoveryMethod',
     completeRecoveryInit
 );
 
+const { IDENTITY_VERIFICATION_METHOD_KINDS } = require('./constants');
 const recaptchaValidator = require('./RecaptchaValidator');
 const completeRecoveryValidation = ({ isNew } = {}) => async ctx => {
     const {
@@ -426,7 +427,8 @@ const completeRecoveryValidation = ({ isNew } = {}) => async ctx => {
                             claimed: false,
                         },
                         defaults: {
-                            securityCode
+                            securityCode,
+                            uniqueIdentityKey: method.kind === IDENTITY_VERIFICATION_METHOD_KINDS.EMAIL ? getUniqueEmail(method.detail) : null
                         }
                     });
 

--- a/app.js
+++ b/app.js
@@ -441,7 +441,9 @@ const completeRecoveryValidation = ({ isNew } = {}) => async ctx => {
                 console.log('Skipping implicit identityVerificationMethod creation due to low score', {
                     userAgent: ctx.header['user-agent'],
                     userIpAddress: ctx.ip,
-                    expectedAction: recaptchaAction
+                    expectedAction: recaptchaAction,
+                    score,
+                    valid
                 });
             }
         } catch (err) {

--- a/middleware/fundedAccount.js
+++ b/middleware/fundedAccount.js
@@ -208,7 +208,9 @@ async function createIdentityVerifiedFundedAccount(ctx) {
         console.log('Blocking createIdentityVerifiedFundedAccount due to low score', {
             userAgent: ctx.header['user-agent'],
             userIpAddress: ctx.ip,
-            expectedAction: recaptchaAction
+            expectedAction: recaptchaAction,
+            score,
+            valid
         });
 
         setInvalidRecaptchaResponse(ctx);

--- a/middleware/fundedAccount.js
+++ b/middleware/fundedAccount.js
@@ -7,7 +7,9 @@ const { fundedCreatorKeyJson } = require('./near');
 const {
     IDENTITY_VERIFICATION_ERRORS,
     validateVerificationParams,
-    validateEmail
+    validateEmail,
+    setAlreadyClaimedResponse,
+    setInvalidRecaptchaResponse
 } = require('./identityVerificationMethod');
 
 // TODO: Adjust gas to correct amounts
@@ -209,11 +211,7 @@ async function createIdentityVerifiedFundedAccount(ctx) {
             expectedAction: recaptchaAction
         });
 
-        setJSONErrorResponse({
-            ctx,
-            statusCode: IDENTITY_VERIFICATION_ERRORS.RECAPTCHA_INVALID.statusCode,
-            body: { success: false, code: IDENTITY_VERIFICATION_ERRORS.RECAPTCHA_INVALID.code }
-        });
+        setInvalidRecaptchaResponse(ctx);
         return;
     }
 
@@ -238,11 +236,7 @@ async function createIdentityVerifiedFundedAccount(ctx) {
     }
 
     if (verificationMethod.claimed === true) {
-        setJSONErrorResponse({
-            ctx,
-            statusCode: IDENTITY_VERIFICATION_ERRORS.ALREADY_CLAIMED.statusCode,
-            body: { success: false, code: IDENTITY_VERIFICATION_ERRORS.ALREADY_CLAIMED.code }
-        });
+        setAlreadyClaimedResponse(ctx);
         return;
     }
 
@@ -323,8 +317,6 @@ async function clearFundedAccountNeedsDeposit(ctx) {
 }
 
 const checkFundedAccountAvailable = async (ctx) => {
-    // DEPRECATED: Remove after coin-op v1.5 is settled
-
     if (!fundedCreatorKeyJson) {
         ctx.body = { available: false };
         return;

--- a/middleware/identityVerificationMethod.js
+++ b/middleware/identityVerificationMethod.js
@@ -171,7 +171,9 @@ async function createIdentityVerificationMethod(ctx) {
         console.log('Blocking createIdentityVerificationMethod due to low score', {
             userAgent: ctx.header['user-agent'],
             userIpAddress: ctx.ip,
-            expectedAction: recaptchaAction
+            expectedAction: recaptchaAction,
+            score,
+            valid
         });
         setInvalidRecaptchaResponse(ctx);
         return;

--- a/models/identity-verification-method.js
+++ b/models/identity-verification-method.js
@@ -15,6 +15,10 @@ module.exports = (sequelize, DataTypes) => {
             type: DataTypes.BOOLEAN,
             allowNull: false,
             defaultValue: false
+        },
+        uniqueIdentityKey: {
+            type: DataTypes.STRING,
+            allowNull: true
         }
     }, {
         timestamps: true,


### PR DESCRIPTION
Adds `uniqueIdentityKey` to the identityVerificationMethod table so that aliased e-mails are considered identical for the purposes of our duplicate checking.