### PR TITLE
Ensure we return NotEnoughBalance errors when coin-op is low on funds

### DIFF
--- a/middleware/fundedAccount.js
+++ b/middleware/fundedAccount.js
@@ -37,7 +37,7 @@ async function doCreateFundedAccount({
     const { available } = await fundingAccount.getAccountBalance();
     const availableBalanceBN = new BN(available);
 
-    if(!availableBalanceBN.gt(nearAPI.utils.format.parseNearAmount('0.5'))) {
+    if (availableBalanceBN.lte(new BN(nearAPI.utils.format.parseNearAmount('0.5')))) {
         // Leave a buffer of 0.5N in coin-op to avoid corner cases where we got 'not enough storage' error instead of
         // NotEnoughBalance error
         setJSONErrorResponse({


### PR DESCRIPTION
- Avoids corner case where we get error about 'not enough storage...' instead of a 'NotEnoughBalance' error from NAJ
- :facepalm: type coercion :tm: