### PR TITLE
2022-01-14 Release

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -11,4 +11,4 @@ TWILIO_ACCOUNT_SID= # account SID from Twilio (used to send security code)
 TWILIO_AUTH_TOKEN= # auth token from Twilio (used to send security code)
 TWILIO_FROM_PHONE=+14086179592 # phone number from which to send SMS with security code (international format, starting with `+`)
 WALLET_URL=https://wallet.nearprotocol.com
-INDEXER_DB_CONNECTION=postgres://<user>:<password>@<domain>/near_indexer_for_wallet_testnet?ssl=require
+INDEXER_DB_CONNECTION=postgres://<user>:<password>@<domain>/near_indexer_for_wallet_testnet

--- a/yarn.lock
+++ b/yarn.lock
@@ -1694,9 +1694,9 @@ flatted@^3.1.0:
   integrity sha512-zAoAQiudy+r5SvnSw3KJy5os/oRJYHzrzja/tBDqrZtNhUw8bt6y8OBzMWcjWr+8liV8Eb6yOhw8WZ7VFZ5ZzA==
 
 follow-redirects@^1.14.0:
-  version "1.14.5"
-  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.14.5.tgz#f09a5848981d3c772b5392309778523f8d85c381"
-  integrity sha512-wtphSXy7d4/OR+MvIFbCVBDzZ5520qV8XfPklSN5QtxuMUJZ+b0Wnst1e1lCDocfzuCkHqj8k0FpZqO+UIaKNA==
+  version "1.14.7"
+  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.14.7.tgz#2004c02eb9436eee9a21446a6477debf17e81685"
+  integrity sha512-+hbxoLbFMbRKDwohX8GkTataGqO6Jb7jGwpAlwgy2bIz25XtRm7KEzJM76R1WiNT5SwZkX4Y75SwBolkpmE7iQ==
 
 foreground-child@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
- Updated follow-redirects dep due to security vuln
- #542 Update pool lookup patterns to find `*.pool.near` validators (v2 'project' pools support)
- Updated sample .env (Thanks @DDeAlmeida ! :))