### PR TITLE
feat: enable USE_DB_SERVICES flag on mainnet

### DIFF
--- a/features/flags.json
+++ b/features/flags.json
@@ -13,9 +13,9 @@
       "lastEditedAt": "2022-01-20T03:44:39.859Z"
     },
     "mainnet": {
-      "enabled": false,
+      "enabled": true,
       "lastEditedBy": "Andy Haynes",
-      "lastEditedAt": "2021-11-30T22:51:54.860Z"
+      "lastEditedAt": "2022-01-27T04:15:37.910Z"
     }
   }
 }


### PR DESCRIPTION
This PR toggles the `USE_DB_SERVICES` feature flag on in the mainnet environments, enabling the usage of the new DB service methods rather than inline SQL queries via `sequelize`.