### PR TITLE
WAL-94 feat: Jenkins AWS deployment

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,9 @@
+FROM node:14-alpine
+
+ENV NODE_ENV=production
+
+WORKDIR /app
+COPY package*.json .
+RUN yarn install --production
+COPY . .
+EXPOSE 3000

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,37 @@
+pipeline {
+    agent any
+    environment {
+        AWS_CREDENTIALS = 'aws-credentials-password'
+        AWS_REGION = 'us-west-2'
+        AWS_TESTNET_ROLE = credentials('testnet-assumed-role')
+        AWS_TESTNET_ROLE_ACCOUNT = credentials('testnet-assumed-role-account')
+
+        ECR_REPOSITORY = 'testnet-ecr-repository'
+        ECS_CLUSTER = 'testnet-cluster'
+        ECS_LIVE_SERVICE = 'testnet-live-backend-service'
+        ECS_STAGING_SERVICE = 'testnet-staging-backend-service'
+    }
+    stages {
+        stage('backend:build') {
+            steps {
+                sh "docker build . --tag $ECR_REPOSITORY"
+            }
+        }
+        stage('backend:deploy') {
+            steps {
+                withAWS(
+                    region: env.AWS_REGION,
+                    credentials: env.AWS_CREDENTIALS,
+                    role: env.AWS_TESTNET_ROLE,
+                    roleAccount: env.AWS_TESTNET_ROLE_ACCOUNT
+                ) {
+                    sh 'ecs-cli configure profile' // initialize ecs-cli with AWS credentials injected by outer withAWS block
+                    sh "ecs-cli push $ECR_REPOSITORY"
+                    sh "aws ecs update-service --service $ECS_STAGING_SERVICE --cluster $ECS_CLUSTER --force-new-deployment"
+                    input(message: 'Deploy to testnet?')
+                    sh "aws ecs update-service --service $ECS_LIVE_SERVICE --cluster $ECS_CLUSTER --force-new-deployment"
+                }
+            }
+        }
+    }
+}

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -60,4 +60,12 @@ pipeline {
             }
         }
     }
+    post {
+        always {
+            cleanWs(
+                disableDeferredWipeout: true,
+                deleteDirs: true
+            )
+        }
+    }
 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -36,9 +36,9 @@ pipeline {
                     milestone(2)
                     sh 'ecs-cli configure profile' // initialize ecs-cli with AWS credentials injected by outer withAWS block
                     sh "ecs-cli push $TESTNET_ECR_REPOSITORY"
-                    sh "aws ecs update-service --service $TESTNET_ECS_STAGING_SERVICE --cluster $TESTNET_ECS_CLUSTER --force-new-deployment"
+                    sh "aws ecs update-service --service $TESTNET_ECS_STAGING_SERVICE --cluster $TESTNET_ECS_CLUSTER"
                     input(message: 'Deploy to testnet?')
-                    sh "aws ecs update-service --service $TESTNET_ECS_LIVE_SERVICE --cluster $TESTNET_ECS_CLUSTER --force-new-deployment"
+                    sh "aws ecs update-service --service $TESTNET_ECS_LIVE_SERVICE --cluster $TESTNET_ECS_CLUSTER"
                 }
             }
         }
@@ -53,9 +53,9 @@ pipeline {
                     milestone(3)
                     sh 'ecs-cli configure profile' // initialize ecs-cli with AWS credentials injected by outer withAWS block
                     sh "ecs-cli push $MAINNET_ECR_REPOSITORY"
-                    sh "aws ecs update-service --service $MAINNET_ECS_STAGING_SERVICE --cluster $MAINNET_ECS_CLUSTER --force-new-deployment"
+                    sh "aws ecs update-service --service $MAINNET_ECS_STAGING_SERVICE --cluster $MAINNET_ECS_CLUSTER"
                     input(message: 'Deploy to mainnet?')
-                    sh "aws ecs update-service --service $MAINNET_ECS_LIVE_SERVICE --cluster $MAINNET_ECS_CLUSTER --force-new-deployment"
+                    sh "aws ecs update-service --service $MAINNET_ECS_LIVE_SERVICE --cluster $MAINNET_ECS_CLUSTER"
                 }
             }
         }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -20,6 +20,7 @@ pipeline {
     stages {
         stage('backend:build') {
             steps {
+                milestone(1)
                 sh "docker build . --tag $TESTNET_ECR_REPOSITORY"
                 sh "docker build . --tag $MAINNET_ECR_REPOSITORY"
             }
@@ -32,6 +33,7 @@ pipeline {
                     role: env.AWS_TESTNET_ROLE,
                     roleAccount: env.AWS_TESTNET_ROLE_ACCOUNT
                 ) {
+                    milestone(2)
                     sh 'ecs-cli configure profile' // initialize ecs-cli with AWS credentials injected by outer withAWS block
                     sh "ecs-cli push $TESTNET_ECR_REPOSITORY"
                     sh "aws ecs update-service --service $TESTNET_ECS_STAGING_SERVICE --cluster $TESTNET_ECS_CLUSTER --force-new-deployment"
@@ -48,6 +50,7 @@ pipeline {
                     role: env.AWS_MAINNET_ROLE,
                     roleAccount: env.AWS_MAINNET_ROLE_ACCOUNT
                 ) {
+                    milestone(3)
                     sh 'ecs-cli configure profile' // initialize ecs-cli with AWS credentials injected by outer withAWS block
                     sh "ecs-cli push $MAINNET_ECR_REPOSITORY"
                     sh "aws ecs update-service --service $MAINNET_ECS_STAGING_SERVICE --cluster $MAINNET_ECS_CLUSTER --force-new-deployment"

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -24,7 +24,7 @@ pipeline {
                 sh "docker build . --tag $MAINNET_ECR_REPOSITORY"
             }
         }
-        stage('backend:deploy') {
+        stage('backend:deploy:testnet') {
             steps {
                 withAWS(
                     region: env.AWS_REGION,
@@ -38,7 +38,10 @@ pipeline {
                     input(message: 'Deploy to testnet?')
                     sh "aws ecs update-service --service $TESTNET_ECS_LIVE_SERVICE --cluster $TESTNET_ECS_CLUSTER --force-new-deployment"
                 }
-
+            }
+        }
+        stage('backend:deploy:mainnet') {
+            steps {
                 withAWS(
                     region: env.AWS_REGION,
                     credentials: env.AWS_CREDENTIALS,

--- a/app.js
+++ b/app.js
@@ -63,6 +63,10 @@ app.use(async function (ctx, next) {
 const Router = require('koa-router');
 const router = new Router();
 
+router.get('/health', (ctx) => {
+    ctx.status = 200;
+});
+
 const {
     withNear,
     checkAccountOwnership,

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "main": "app.js",
   "scripts": {
     "start": "env $(sed 's/ # .*//' .env) supervisor app",
+    "docker:start": "node app.js",
     "test": "yarn lint && mocha",
     "lint": "eslint .",
     "fix": "eslint . --fix",


### PR DESCRIPTION
This PR adds a Jenkinsfile for deploying to the new AWS environments. The container defined in the new `Dockerfile` is built and pushed to ECR before updating the staging and live services running on the target environment's ECS cluster.