### PR TITLE
WAL-95 fix: add resolutions for transient dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,5 +69,9 @@
     "sinon-chai": "^3.6.0",
     "supertest": "^6.1.3",
     "supervisor": "^0.12.0"
+  },
+  "resolutions": {
+    "**/node-fetch": "2.6.7",
+    "**/node-forge": "1.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   },
   "homepage": "https://github.com/nearprotocol/near-contract-helper#readme",
   "dependencies": {
-    "@google-cloud/recaptcha-enterprise": "^2.3.0",
+    "@google-cloud/recaptcha-enterprise": "^2.5.0",
     "@koa/cors": "^3.0.0",
     "@near-wallet/feature-flags": "^0.0.4",
     "@sentry/node": "^6.5.1",
@@ -71,7 +71,6 @@
     "supervisor": "^0.12.0"
   },
   "resolutions": {
-    "**/node-fetch": "2.6.7",
-    "**/node-forge": "1.0.0"
+    "**/node-fetch": "2.6.7"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -312,10 +312,10 @@
     minimatch "^3.0.4"
     strip-json-comments "^3.1.1"
 
-"@google-cloud/recaptcha-enterprise@^2.3.0":
-  version "2.3.0"
-  resolved "https://registry.yarnpkg.com/@google-cloud/recaptcha-enterprise/-/recaptcha-enterprise-2.3.0.tgz#b81535e8d1dde825abc3b79366f1b427ce72ada1"
-  integrity sha512-FndSnpMjF7YQIlVq5YIAHnVd7SFdHHUMccY3aJdBOTkDcGs5+78BQEpggl0DfAtCZ6B6W6vd8RHeqxjAcJyNMg==
+"@google-cloud/recaptcha-enterprise@^2.5.0":
+  version "2.5.0"
+  resolved "https://registry.yarnpkg.com/@google-cloud/recaptcha-enterprise/-/recaptcha-enterprise-2.5.0.tgz#33f8b8f6a0eb7555c290149af201d89f149cae90"
+  integrity sha512-wcK6sAmdDMc/q6O19hrfZQNXmKwaAvMvqOe2djUsKAg9b/P8kTzhTFBGgSLARnqRGVgORZMfpnLyPyeoe4OwcA==
   dependencies:
     google-gax "^2.24.1"
 
@@ -2964,10 +2964,12 @@ node-cache@^5.1.2:
   dependencies:
     clone "2.x"
 
-node-fetch@^2.6.1:
-  version "2.6.1"
-  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.1.tgz#045bd323631f76ed2e2b55573394416b639a0052"
-  integrity sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw==
+node-fetch@2.6.7, node-fetch@^2.6.1:
+  version "2.6.7"
+  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.7.tgz#24de9fba827e3b4ae44dc8b20256a379160052ad"
+  integrity sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==
+  dependencies:
+    whatwg-url "^5.0.0"
 
 node-forge@^0.10.0:
   version "0.10.0"
@@ -3947,6 +3949,11 @@ toposort-class@^1.0.1:
   resolved "https://registry.yarnpkg.com/toposort-class/-/toposort-class-1.0.1.tgz#7ffd1f78c8be28c3ba45cd4e1a3f5ee193bd9988"
   integrity sha1-f/0feMi+KMO6Rc1OGj9e4ZO9mYg=
 
+tr46@~0.0.3:
+  version "0.0.3"
+  resolved "https://registry.yarnpkg.com/tr46/-/tr46-0.0.3.tgz#8184fd347dac9cdc185992f3a6622e14b9d9ab6a"
+  integrity sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o=
+
 tslib@^1.9.3:
   version "1.14.1"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.14.1.tgz#cf2d38bdc34a134bcaf1091c41f6619e2f672d00"
@@ -4119,6 +4126,19 @@ weak-map@^1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/weak-map/-/weak-map-1.0.5.tgz#79691584d98607f5070bd3b70a40e6bb22e401eb"
   integrity sha1-eWkVhNmGB/UHC9O3CkDmuyLkAes=
+
+webidl-conversions@^3.0.0:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/webidl-conversions/-/webidl-conversions-3.0.1.tgz#24534275e2a7bc6be7bc86611cc16ae0a5654871"
+  integrity sha1-JFNCdeKnvGvnvIZhHMFq4KVlSHE=
+
+whatwg-url@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/whatwg-url/-/whatwg-url-5.0.0.tgz#966454e8765462e37644d3626f6742ce8b70965d"
+  integrity sha1-lmRU6HZUYuN2RNNib2dCzotwll0=
+  dependencies:
+    tr46 "~0.0.3"
+    webidl-conversions "^3.0.0"
 
 which-module@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
This PR seeks to update the transient dependencies with vulnerabilities, which currently break FOSSA tests