### PR TITLE
feat(2fa): don't bypass initial 2FA verification for existing recovery methods

### DIFF
--- a/middleware/2fa.js
+++ b/middleware/2fa.js
@@ -263,21 +263,6 @@ const initCode = async (ctx) => {
         });
     }
 
-    // check if 2fa method matches existing recovery method
-    const [recoveryMethod] = await recoveryMethodService.listRecoveryMethods({
-        accountId,
-        detail,
-        kind: kind.split('2fa-')[1],
-    });
-
-    if (recoveryMethod) {
-        // client should deploy contract
-        ctx.body = {
-            confirmed: true, message: '2fa initialized and set up using recovery method verification'
-        };
-        return;
-    }
-
     // client waits to deploy contract until code is verified
     await sendCode(ctx, method, -1, accountId);
     ctx.body = {


### PR DESCRIPTION
When a user signs up for 2FA with an email address/SMS number that is already used as a recovery method, the current behavior is to not send the initial verification code as the communication channel has already been verified by virtue of belonging to an existing recovery method owned by the account holder. However this behavior can be unexpected and give the impression to users that their 2FA contract is not securely configured, undermining any convenience that this behavior may have sought to provide.

By ceasing to query for a corresponding recovery method, we ensure that the enabling 2FA always sends an initial code for the user to verify.

Closes #558 