### PR TITLE
WAL-92 DynamoDB services updates

### DIFF
--- a/app.js
+++ b/app.js
@@ -433,15 +433,28 @@ const completeRecoveryValidation = ({ isNew } = {}) => async (ctx) => {
         ctx.throw(401, 'account does not exist');
     }
 
-    const [recoveryMethod] = await recoveryMethodService.listRecoveryMethods({
-        accountId,
-        detail: method.detail,
-        kind: method.kind,
-        securityCode,
-    });
+    if (!USE_DYNAMODB) {
+        const [recoveryMethod] = await recoveryMethodService.listRecoveryMethods({
+            accountId,
+            detail: method.detail,
+            kind: method.kind,
+            securityCode,
+        });
 
-    if (!recoveryMethod) {
-        ctx.throw(401, 'recoveryMethod does not exist');
+        if (!recoveryMethod) {
+            ctx.throw(401, 'recoveryMethod does not exist');
+        }
+    } else {
+        const isValidRecoveryMethod = await recoveryMethodService.validateSecurityCode({
+            accountId,
+            detail: method.detail,
+            kind: method.kind,
+            securityCode,
+        });
+
+        if (!isValidRecoveryMethod) {
+            ctx.throw(401, 'recoveryMethod does not exist');
+        }
     }
 
     // for new accounts, clear all other recovery methods that may have been created

--- a/db/dynamo.js
+++ b/db/dynamo.js
@@ -7,7 +7,7 @@ function createDocument(schema, object, params) {
 
 function deleteDocument(schema, object, params) {
     return schema.destroyAsync(object, { ReturnValues: 'ALL_OLD', ...params })
-        .then((document) => document.toJSON());
+        .then((document) => document && document.toJSON());
 }
 
 function getDocument(schema, keys) {

--- a/db/methods/recovery_method/update.js
+++ b/db/methods/recovery_method/update.js
@@ -2,7 +2,7 @@ const { updateDocument } = require('../../dynamo');
 const RecoveryMethod = require('../../schemas/recovery_method');
 const { buildRecoveryMethodRangeKey } = require('../../utils');
 
-function updateRecoveryMethod({ accountId, detail, kind, publicKey }, { requestId, securityCode }) {
+function updateRecoveryMethod({ accountId, kind, publicKey }, { detail, requestId, securityCode }) {
     return updateDocument(RecoveryMethod, {
         accountId,
         compositeKey: buildRecoveryMethodRangeKey({ kind, publicKey }),

--- a/services/recovery_method.js
+++ b/services/recovery_method.js
@@ -209,6 +209,17 @@ class RecoveryMethodService {
             securityCode,
         });
     }
+
+    async validateSecurityCode({ accountId, detail, kind, securityCode }) {
+        const [recoveryMethod] = await this.db.listRecoveryMethodsByAccountId(accountId)
+            .filter((recoveryMethod) =>
+                recoveryMethod.detail === detail
+                && recoveryMethod.kind === kind
+                && recoveryMethod.securityCode === securityCode
+            );
+
+        return !!recoveryMethod;
+    }
 }
 
 module.exports = RecoveryMethodService;

--- a/services/recovery_method.js
+++ b/services/recovery_method.js
@@ -1,4 +1,3 @@
-const { RECOVERY_METHOD_KINDS } = require('../constants');
 const {
     createRecoveryMethod,
     deleteRecoveryMethod,
@@ -92,50 +91,13 @@ class RecoveryMethodService {
     }
 
     async listRecoveryMethods({ accountId, detail, kind, publicKey, securityCode }) {
-        if (!USE_DYNAMODB) {
-            return this.sequelize.listRecoveryMethods({
-                accountId,
-                detail,
-                kind,
-                publicKey,
-                securityCode
-            });
-        }
-
-        const hasSecurityCode = !!(securityCode || parseInt(securityCode, 10) === 0);
-
-        // the table keys can be used to uniquely identify a recovery method document if either:
-        // - all constituent properties of the composite index are provided to this method
-        // - the recovery method kind indicates that a value for detail will never be reported because it does not exist or is private
-        // if neither condition is met then the property either does not exist or has been omitted, but the
-        // since the distinction cannot reliably be made, all recovery methods for the account will be fetched
-        const hasConstituentKeys = detail && kind && publicKey;
-        const noDetailReported = [
-            RECOVERY_METHOD_KINDS.LEDGER,
-            RECOVERY_METHOD_KINDS.PHRASE,
-        ].includes(kind);
-
-        if (noDetailReported || hasConstituentKeys) {
-            const recoveryMethod = await this.db.getRecoveryMethodByIdentity({
-                accountId,
-                kind,
-                publicKey,
-            });
-
-            if (!recoveryMethod || (hasSecurityCode && recoveryMethod.securityCode !== securityCode)) {
-                return [];
-            }
-
-            return [recoveryMethod];
-        }
-
-        return this.db.listRecoveryMethodsByAccountId(accountId)
-            .filter((recoveryMethod) =>
-                (!detail || detail === recoveryMethod.detail)
-                && (!kind || kind === recoveryMethod.kind)
-                && (!publicKey || publicKey === recoveryMethod.publicKey)
-                && (!hasSecurityCode || securityCode === recoveryMethod.securityCode)
-            );
+        return this.sequelize.listRecoveryMethods({
+            accountId,
+            detail,
+            kind,
+            publicKey,
+            securityCode
+        });
     }
 
     async resetTwoFactorRequest(accountId) {

--- a/services/recovery_method.js
+++ b/services/recovery_method.js
@@ -111,10 +111,10 @@ class RecoveryMethodService {
 
         return this.db.updateRecoveryMethod({
             accountId,
-            detail: twoFactorRecoveryMethod.detail,
             kind: twoFactorRecoveryMethod.kind,
             publicKey: twoFactorRecoveryMethod.publicKey,
         }, {
+            detail: twoFactorRecoveryMethod.detail,
             requestId: -1,
             securityCode: null,
         });
@@ -136,10 +136,10 @@ class RecoveryMethodService {
         }
         return this.db.updateRecoveryMethod({
             accountId,
-            detail,
             kind,
             publicKey,
         }, {
+            detail,
             securityCode,
         });
     }
@@ -163,10 +163,10 @@ class RecoveryMethodService {
 
         return this.db.updateRecoveryMethod({
             accountId,
-            detail: twoFactorRecoveryMethod.detail,
             kind: twoFactorRecoveryMethod.kind,
             publicKey: twoFactorRecoveryMethod.publicKey,
         }, {
+            detail: twoFactorRecoveryMethod.detail,
             requestId,
             securityCode,
         });


### PR DESCRIPTION
This PR is a follow-up to #550 to address some minor bugs and clean up some unnecessarily confusing logic:
- DB methods deleting documents are no longer expected to always return the deleted document (this may be a bug in the DynamoDB library we're using but doesn't affect any code currently).
- `detail` has been removed from the set of key parameters when updating recovery methods as it is no longer part of the composite range key.
- The `listRecoveryMethods` method has been replaced with a new method (`validateSecurityCode`) to verify that the requested recovery method exists with the provided security code. This removes the catch-all filter logic in `listRecoveryMethods`, a method which now is only called when `USE_DYNAMODB` is disabled and can be deleted once the flag is removed 🎉 