### PR TITLE
WAL-160 DynamoDB fixes

### DIFF
--- a/app.js
+++ b/app.js
@@ -420,6 +420,7 @@ const completeRecoveryValidation = ({ isNew } = {}) => async (ctx) => {
         method,
         securityCode,
         enterpriseRecaptchaToken,
+        publicKey,
         recaptchaAction,
         recaptchaSiteKey
     } = ctx.request.body;
@@ -449,6 +450,7 @@ const completeRecoveryValidation = ({ isNew } = {}) => async (ctx) => {
             accountId,
             detail: method.detail,
             kind: method.kind,
+            publicKey,
             securityCode,
         });
 
@@ -466,6 +468,7 @@ const completeRecoveryValidation = ({ isNew } = {}) => async (ctx) => {
         accountId,
         detail: method.detail,
         kind: method.kind,
+        publicKey,
         securityCode: null,
     });
 

--- a/db/methods/recovery_method/update.js
+++ b/db/methods/recovery_method/update.js
@@ -11,6 +11,9 @@ function updateRecoveryMethod({ accountId, kind, publicKey }, { detail, requestI
         publicKey,
         requestId,
         securityCode,
+    }, {
+        UpdateExpression: 'SET createdAt = if_not_exists(createdAt, :now)',
+        ExpressionAttributeValues: { ':now': (new Date()).toISOString() },
     });
 }
 

--- a/middleware/fundedAccount.js
+++ b/middleware/fundedAccount.js
@@ -1,6 +1,7 @@
 const nearAPI = require('near-api-js');
 const BN = require('bn.js');
 
+const { USE_DYNAMODB } = require('../features');
 const recaptchaValidator = require('../RecaptchaValidator');
 const AccountService = require('../services/account');
 const IdentityVerificationMethodService = require('../services/identity_verification_method');
@@ -234,6 +235,7 @@ async function createIdentityVerifiedFundedAccount(ctx) {
 
     const verificationMethod = await identityVerificationMethodService.getIdentityVerificationMethod({
         identityKey,
+        ...(USE_DYNAMODB ? {} : { kind }),
     });
 
     if (!verificationMethod) {

--- a/services/identity_verification_method.js
+++ b/services/identity_verification_method.js
@@ -29,7 +29,7 @@ class IdentityVerificationMethodService {
             return null;
         }
 
-        return updateIdentityVerificationMethod({
+        return this.db.updateIdentityVerificationMethod({
             uniqueIdentityKey: this.getUniqueIdentityKey(identityKey),
         }, {
             claimed: true,

--- a/services/recovery_method.js
+++ b/services/recovery_method.js
@@ -52,7 +52,7 @@ class RecoveryMethodService {
         }
         return this.db.listRecoveryMethodsByAccountId(accountId)
             .filter((recoveryMethod) => recoveryMethod.detail !== detail)
-            .map((recoveryMethod) => deleteRecoveryMethod(recoveryMethod));
+            .map((recoveryMethod) => this.db.deleteRecoveryMethod(recoveryMethod));
     }
 
     deleteRecoveryMethod({ accountId, kind, publicKey }) {
@@ -61,7 +61,7 @@ class RecoveryMethodService {
         }
         return this.db.listRecoveryMethodsByAccountId(accountId)
             .filter((recoveryMethod) => recoveryMethod.kind === kind && recoveryMethod.publicKey === publicKey)
-            .map((recoveryMethod) => deleteRecoveryMethod(recoveryMethod));
+            .map((recoveryMethod) => this.db.deleteRecoveryMethod(recoveryMethod));
     }
 
     getTwoFactorRecoveryMethod(accountId) {

--- a/services/recovery_method.js
+++ b/services/recovery_method.js
@@ -172,15 +172,25 @@ class RecoveryMethodService {
         });
     }
 
-    async validateSecurityCode({ accountId, detail, kind, securityCode }) {
-        const [recoveryMethod] = await this.db.listRecoveryMethodsByAccountId(accountId)
-            .filter((recoveryMethod) =>
-                recoveryMethod.detail === detail
-                && recoveryMethod.kind === kind
-                && recoveryMethod.securityCode === securityCode
-            );
+    async validateSecurityCode({ accountId, detail, kind, publicKey, securityCode }) {
+        if (!publicKey) {
+            const [recoveryMethod] = await this.db.listRecoveryMethodsByAccountId(accountId)
+                .filter((recoveryMethod) =>
+                    recoveryMethod.detail === detail
+                    && recoveryMethod.kind === kind
+                    && recoveryMethod.securityCode === securityCode
+                );
 
-        return !!recoveryMethod;
+            return !!recoveryMethod;
+        }
+
+        const recoveryMethod = await this.db.getRecoveryMethodByIdentity({
+            accountId,
+            kind,
+            publicKey,
+        });
+
+        return !!recoveryMethod && recoveryMethod.securityCode === securityCode;
     }
 }
 


### PR DESCRIPTION
This PR addresses issues outlined in [WAL-160](https://nearinc.atlassian.net/browse/WAL-160):
- adds an update expression to the recovery method `update` DB method to ensure a value for `createdAt` when document is created via upsert
- use `publicKey` in recovery method validation endpoints to ensure the full range key can be composed (requires [near-wallet PR](https://github.com/near/near-wallet/pull/2529))
- update service calls to always use the DB methods injected in the service constructor, not the DB method imported into module scope
- restore the missing `kind` parameter to `getIdentityVerificationMethod` call when querying Postgres (removed in #550)