### PR TITLE
test(db): update tests for DynamoDB integration

### DIFF
--- a/db/schemas/recovery_method.js
+++ b/db/schemas/recovery_method.js
@@ -16,7 +16,7 @@ const RecoveryMethod = dynamo.define('RecoveryMethod', {
         compositeKey: Joi.string().required(),
         detail: Joi.string(),
         kind: Joi.string().valid(...validRecoveryKinds).required(),
-        publicKey: Joi.string(),
+        publicKey: Joi.string().allow(null),
         requestId: Joi.number().integer(),
         securityCode: Joi.string(),
     },

--- a/middleware/fundedAccount.js
+++ b/middleware/fundedAccount.js
@@ -253,7 +253,7 @@ async function createIdentityVerifiedFundedAccount(ctx) {
     }
 
     // 15 minute expiration for codes; don't allow anything older to be used.
-    if ((Date.now().valueOf() - verificationMethod.updatedAt.valueOf()) > (60 * 1000 * 15)) {
+    if ((Date.now().valueOf() - (new Date(verificationMethod.updatedAt)).valueOf()) > (60 * 1000 * 15)) {
         setJSONErrorResponse({
             ctx,
             statusCode: IDENTITY_VERIFICATION_ERRORS.VERIFICATION_CODE_EXPIRED.statusCode,

--- a/services/identity_verification_method.js
+++ b/services/identity_verification_method.js
@@ -74,7 +74,11 @@ class IdentityVerificationMethodService {
 
         // allow recovery when no record exists for the given identity or the record is unclaimed and matches the given kind
         const isRecoverable = !identityVerificationMethod
-            || (identityVerificationMethod.kind === kind && !identityVerificationMethod.claimed);
+            || (
+                identityVerificationMethod.kind === kind
+                && identityVerificationMethod.identityKey === identityKey
+                && !identityVerificationMethod.claimed
+            );
 
         if (!isRecoverable) {
             return false;

--- a/services/recovery_method.js
+++ b/services/recovery_method.js
@@ -90,6 +90,7 @@ class RecoveryMethodService {
             }));
     }
 
+    // TODO remove this method when removing the USE_DYNAMODB feature flag
     async listRecoveryMethods({ accountId, detail, kind, publicKey, securityCode }) {
         return this.sequelize.listRecoveryMethods({
             accountId,
@@ -190,7 +191,7 @@ class RecoveryMethodService {
             publicKey,
         });
 
-        return !!recoveryMethod && recoveryMethod.securityCode === securityCode;
+        return !!recoveryMethod && recoveryMethod.detail === detail && recoveryMethod.securityCode === securityCode;
     }
 }
 

--- a/services/recovery_method.js
+++ b/services/recovery_method.js
@@ -75,7 +75,7 @@ class RecoveryMethodService {
     }
 
     isTwoFactorRequestExpired({ updatedAt }) {
-        return updatedAt < (Date.now() - TWO_FACTOR_REQUEST_DURATION_MS);
+        return (new Date(updatedAt)) < (Date.now() - TWO_FACTOR_REQUEST_DURATION_MS);
     }
 
     listAllRecoveryMethods(accountId) {

--- a/test/.env.test
+++ b/test/.env.test
@@ -5,3 +5,6 @@ FUNDED_ACCOUNT_CREATOR_KEY={"account_id":"test.near","secret_key":"ed25519:2wyRc
 WALLET_URL=https://wallet.nearprotocol.com
 NEW_ACCOUNT_AMOUNT=500000001000000000000000000
 NODE_URL=https://rpc.ci-testnet.near.org
+AWS_REGION=region
+AWS_ACCESS_KEY_ID=access_key
+AWS_SECRET_ACCESS_KEY=secret

--- a/test/2fa.test.js
+++ b/test/2fa.test.js
@@ -119,7 +119,7 @@ describe('2fa method management', function () {
         });
 
         it('sends a code when the 2FA email address is already being used with an email recovery method', async () => {
-            await accountService.createAccount(accountId);
+            await accountService.getOrCreateAccount(accountId);
             await recoveryMethodService.createRecoveryMethod({
                 ...twoFactorMethods.email,
                 accountId,

--- a/test/TestAccountHelper.js
+++ b/test/TestAccountHelper.js
@@ -88,19 +88,20 @@ class TestAccountHelper {
         });
     }
 
-    async initRecoveryMethodForTempAccount({ accountId, method }) {
+    async initRecoveryMethodForTempAccount({ accountId, method, seedPhrase }) {
         this.clearSecurityCodeForAccount(accountId);
 
         const result = await this._request.post('/account/initializeRecoveryMethodForTempAccount')
             .send({
                 accountId,
                 method,
+                seedPhrase,
             });
 
         return { result, securityCode: this.getSecurityCodeForAccount(accountId) };
     }
 
-    async initRecoveryMethod({ accountId, method, testing, valid }) {
+    async initRecoveryMethod({ accountId, method, seedPhrase, testing, valid }) {
         const signature = await this.signatureForLatestBlock({ accountId, valid });
 
         this.clearSecurityCodeForAccount(accountId);
@@ -109,6 +110,7 @@ class TestAccountHelper {
             .send({
                 accountId,
                 method,
+                seedPhrase,
                 testing,
                 ...signature,
             });

--- a/test/app.test.js
+++ b/test/app.test.js
@@ -103,7 +103,8 @@ describe('app routes', function () {
         it('send security code', async () => {
             ({ result, securityCode: savedSecurityCode } = await testAccountHelper.initRecoveryMethodForTempAccount({
                 accountId,
-                method
+                method,
+                seedPhrase: SEED_PHRASE,
             }));
 
             expectJSONResponse(result);
@@ -153,14 +154,19 @@ describe('app routes', function () {
         it('send security code alice', async () => {
             ({ result, securityCode: savedSecurityCode } = await testAccountHelper.initRecoveryMethodForTempAccount({
                 accountId,
-                method: alice
+                method: alice,
+                seedPhrase: 'any athlete that pudding ramp car pyramid share example day slab protect',
             }));
 
             expectJSONResponse(result);
         });
 
         it('send security code bob', async () => {
-            const { result } = await testAccountHelper.initRecoveryMethodForTempAccount(({ accountId, method: bob }));
+            const { result } = await testAccountHelper.initRecoveryMethodForTempAccount(({
+                accountId,
+                method: bob,
+                seedPhrase: 'coach early mad link yard express that crack wheel valid armor laundry',
+            }));
 
             expectJSONResponse(result);
         });
@@ -196,7 +202,8 @@ describe('app routes', function () {
             ({ result, securityCode: savedSecurityCode } = await testAccountHelper.initRecoveryMethod({
                 accountId,
                 method,
-                testing
+                seedPhrase: SEED_PHRASE,
+                testing,
             }));
 
             expectJSONResponse(result);

--- a/test/app.test.js
+++ b/test/app.test.js
@@ -97,7 +97,7 @@ describe('app routes', function () {
 
     describe('/account/initializeRecoveryMethodForTempAccount', () => {
         let savedSecurityCode = '', result;
-        const accountId = 'doesnotexistonchain' + Date.now();
+        const accountId = 'doesnotexistonchain_1' + Date.now();
         const method = recoveryMethods[RECOVERY_METHOD_KINDS.EMAIL];
 
         it('send security code', async () => {
@@ -142,20 +142,21 @@ describe('app routes', function () {
                 })
                 .then(expectJSONResponse);
         });
-
     });
 
     describe('Two people send recovery methods for the same account before created', () => {
         let savedSecurityCode = '', result;
-        const accountId = 'doesnotexistonchain' + Date.now();
+        const accountId = 'doesnotexistonchain_2' + Date.now();
         const alice = recoveryMethods[RECOVERY_METHOD_KINDS.EMAIL];
         const bob = recoveryMethods[RECOVERY_METHOD_KINDS.PHONE];
+        const aliceSeedPhrase = 'any athlete that pudding ramp car pyramid share example day slab protect';
+        const bobSeedPhrase = 'coach early mad link yard express that crack wheel valid armor laundry';
 
         it('send security code alice', async () => {
             ({ result, securityCode: savedSecurityCode } = await testAccountHelper.initRecoveryMethodForTempAccount({
                 accountId,
                 method: alice,
-                seedPhrase: 'any athlete that pudding ramp car pyramid share example day slab protect',
+                seedPhrase: aliceSeedPhrase,
             }));
 
             expectJSONResponse(result);
@@ -165,17 +166,19 @@ describe('app routes', function () {
             const { result } = await testAccountHelper.initRecoveryMethodForTempAccount(({
                 accountId,
                 method: bob,
-                seedPhrase: 'coach early mad link yard express that crack wheel valid armor laundry',
+                seedPhrase: bobSeedPhrase,
             }));
 
             expectJSONResponse(result);
         });
 
         it('validate security code alice (new account) and other methods should be removed leaving 1 recoveryMethod', async () => {
+            const { publicKey } = parseSeedPhrase(aliceSeedPhrase);
             await request.post('/account/validateSecurityCodeForTempAccount')
                 .send({
                     accountId,
                     method: alice,
+                    publicKey,
                     securityCode: savedSecurityCode,
                 })
                 .then(expectJSONResponse);

--- a/test/local_dynamo.js
+++ b/test/local_dynamo.js
@@ -1,12 +1,12 @@
 const { DocumentClient } = require('aws-sdk/clients/dynamodb');
 const Promise = require('bluebird');
-const dynamo = Promise.promisifyAll(require('dynamodb'));
+const dynamo = require('dynamodb');
 const dynamoLocal = require('dynamodb-local');
 
-require('../db/schemas/account');
-require('../db/schemas/email_domain_blacklist');
-require('../db/schemas/identity_verification_method');
-require('../db/schemas/recovery_method');
+const Account = require('../db/schemas/account');
+const EmailDomainBlacklist = require('../db/schemas/email_domain_blacklist');
+const IdentityVerificationMethod = require('../db/schemas/identity_verification_method');
+const RecoveryMethod = require('../db/schemas/recovery_method');
 
 const LOCAL_DYNAMODB_PORT = 8000;
 
@@ -18,8 +18,13 @@ async function initLocalDynamo() {
         region: 'local-env'
     }));
 
-    await dynamoLocal.launch(LOCAL_DYNAMODB_PORT, null);//, ['-shareDb']);
-    await dynamo.createTablesAsync();
+    await dynamoLocal.launch(LOCAL_DYNAMODB_PORT);
+    await Promise.all([
+        Account,
+        EmailDomainBlacklist,
+        IdentityVerificationMethod,
+        RecoveryMethod,
+    ].map((model) => model.createTableAsync()));
 
     return {
         terminateLocalDynamo: () => dynamoLocal.stop(LOCAL_DYNAMODB_PORT),

--- a/test/services/account.js
+++ b/test/services/account.js
@@ -1,3 +1,5 @@
+require('dotenv').config({ path: 'test/.env.test' });
+
 const { USE_DYNAMODB } = require('../../features');
 const AccountService = require('../../services/account');
 const chai = require('../chai');

--- a/test/services/email_domain_blacklist.js
+++ b/test/services/email_domain_blacklist.js
@@ -1,3 +1,5 @@
+require('dotenv').config({ path: 'test/.env.test' });
+
 const EmailDomainBlacklistService = require('../../services/email_domain_blacklist');
 const chai = require('../chai');
 const { deleteAllRows } = require('../db');

--- a/test/services/identity_verification_method.js
+++ b/test/services/identity_verification_method.js
@@ -1,3 +1,5 @@
+require('dotenv').config({ path: 'test/.env.test' });
+
 const Constants = require('../../constants');
 const IdentityVerificationMethodService = require('../../services/identity_verification_method');
 const IdentityVerificationMethodSequelize = require('../../services/sequelize/identity_verification_method');

--- a/test/services/recovery_method.js
+++ b/test/services/recovery_method.js
@@ -23,7 +23,7 @@ const recoveryMethodService = new RecoveryMethodService();
 describe('RecoveryMethodService', function () {
     beforeEach(async function () {
         if (USE_DYNAMODB) {
-            const methods = await recoveryMethodService.listRecoveryMethods({ accountId: ACCOUNT_ID });
+            const methods = await recoveryMethodService.listAllRecoveryMethods(ACCOUNT_ID);
             await Promise.all(methods.map((method) => recoveryMethodService.deleteRecoveryMethod(method)));
         } else {
             await deleteAllRows();

--- a/test/services/recovery_method.js
+++ b/test/services/recovery_method.js
@@ -70,12 +70,14 @@ describe('RecoveryMethodService', function () {
                     accountId: ACCOUNT_ID,
                     detail: email,
                     kind: IDENTITY_VERIFICATION_METHOD_KINDS.EMAIL,
+                    publicKey: 'abc',
                     securityCode: SECURITY_CODE,
                 }),
                 recoveryMethodService.createRecoveryMethod({
                     accountId: ACCOUNT_ID,
                     detail: secondaryEmail,
                     kind: IDENTITY_VERIFICATION_METHOD_KINDS.EMAIL,
+                    publicKey: 'xyz',
                     securityCode: SECURITY_CODE,
                 })
             ]);

--- a/test/services/recovery_method.js
+++ b/test/services/recovery_method.js
@@ -1,4 +1,5 @@
 const Promise = require('bluebird');
+require('dotenv').config({ path: 'test/.env.test' });
 
 const Constants = require('../../constants');
 const { USE_DYNAMODB } = require('../../features');

--- a/test/services/recovery_method.js
+++ b/test/services/recovery_method.js
@@ -184,7 +184,7 @@ describe('RecoveryMethodService', function () {
         });
     });
 
-    describe('listRecoveryMethods', function () {
+    (USE_DYNAMODB ? describe.skip : describe)('listRecoveryMethods', function () {
         it('returns all recovery methods for the given detail and kind', async function () {
             const email = generateEmailAddress();
             await Promise.all([


### PR DESCRIPTION
This PR addresses breaking tests when the `USE_DYNAMODB` feature flag is enabled, as well as adding test coverage for new methods and deprecating coverage for methods not called when `USE_DYNAMODB` is enabled.

These changes to are primarily due to minor disparities between how `sequelize` and `dynamodb` handle particular data interactions but also include one-off changes to existing tests for more consistent behavior and to accommodate the in-memory DynamoDB instance, including:
- validation of `null` input values
- casting of date types returned from the DB
- record creation behavior when a matching record already exists
- missing comparison of data points
- providing missing data to endpoints