### PR TITLE
refactor(indexer): recent transactions query tuning

### DIFF
--- a/middleware/indexer.js
+++ b/middleware/indexer.js
@@ -80,7 +80,7 @@ const findAccountActivity = async (ctx) => {
             select *
             from predecessor_receipts
 
-            union all
+            union
 
             select *
             from receiver_receipts

--- a/middleware/indexer.js
+++ b/middleware/indexer.js
@@ -85,14 +85,14 @@ const findAccountActivity = async (ctx) => {
             select *
             from receiver_receipts
         )
-        select  ar.action_index
-            ,   ar.action_kind
-            ,   ar.args
-            ,   r.included_in_block_hash as block_hash
+        select  r.included_in_block_hash as block_hash
             ,   r.included_in_block_timestamp as block_timestamp
             ,   r.originated_from_transaction_hash as hash
+            ,   ar.action_index
             ,   r.predecessor_account_id as signer_id
             ,   r.receiver_account_id as receiver_id
+            ,   ar.action_kind
+            ,   ar.args
         from account_receipts as ar
         join receipts as r
             on r.receipt_id = ar.receipt_id


### PR DESCRIPTION
This PR refactors the SQL indexer query responsible for fetching the 10 most recent transactions for a given account. The new query returns exactly the same data but has been rewritten with CTEs to filter the set of rows from `action_receipt_actions` before joining on `receipts`.

Highlights from differences in `EXPLAIN ANALYZE`:
Before: `Limit  (cost=54057.77..54070.61 rows=110 width=385) (actual time=46.483..52.653 rows=97 loops=1)`
After: `Limit  (cost=17650.94..17650.96 rows=10 width=187) (actual time=1.450..1.457 rows=10 loops=1)`

Before: `->  Nested Loop  (cost=381.50..52830.61 rows=5838 width=385) (actual time=0.364..1.818 rows=32 loops=3)`
After: `->  Nested Loop  (cost=0.70..64.70 rows=20 width=187) (actual time=0.862..1.403 rows=13 loops=1)`


Original query results from Postgres `EXPLAIN ANALYZE`:
```
Limit  (cost=54057.77..54070.61 rows=110 width=385) (actual time=46.483..52.653 rows=97 loops=1)
--
->  Gather Merge  (cost=54057.77..55420.07 rows=11676 width=385) (actual time=46.481..52.633 rows=97 loops=1)
Workers Planned: 2
Workers Launched: 2
->  Sort  (cost=53057.75..53072.34 rows=5838 width=385) (actual time=2.020..2.035 rows=32 loops=3)
Sort Key: action_receipt_actions.receipt_included_in_block_timestamp DESC
Sort Method: quicksort  Memory: 73kB
Worker 0:  Sort Method: quicksort  Memory: 25kB
Worker 1:  Sort Method: quicksort  Memory: 25kB
->  Nested Loop  (cost=381.50..52830.61 rows=5838 width=385) (actual time=0.364..1.818 rows=32 loops=3)
->  Parallel Bitmap Heap Scan on action_receipt_actions  (cost=380.81..34078.63 rows=5838 width=302) (actual time=0.340..0.550 rows=32 loops=3)
Recheck Cond: ((receipt_predecessor_account_id = 'andyh.near'::text) OR (receipt_receiver_account_id = 'andyh.near'::text))
Filter: ((receipt_predecessor_account_id <> 'system'::text) AND ('9999999999999999999'::numeric > receipt_included_in_block_timestamp))
Rows Removed by Filter: 17
Heap Blocks: exact=106
->  BitmapOr  (cost=380.81..380.81 rows=27022 width=0) (actual time=0.786..0.788 rows=0 loops=1)
->  Bitmap Index Scan on action_receipt_actions_receipt_predecessor_account_id_idx  (cost=0.00..195.02 rows=14760 width=0) (actual time=0.742..0.742 rows=84 loops=1)
Index Cond: (receipt_predecessor_account_id = 'andyh.near'::text)
->  Bitmap Index Scan on action_receipt_actions_receipt_receiver_account_id_idx  (cost=0.00..178.78 rows=12261 width=0) (actual time=0.043..0.043 rows=130 loops=1)
Index Cond: (receipt_receiver_account_id = 'andyh.near'::text)
->  Index Scan using receipts_pkey on receipts  (cost=0.70..3.21 rows=1 width=171) (actual time=0.037..0.037 rows=1 loops=97)
Index Cond: (receipt_id = action_receipt_actions.receipt_id)
Planning Time: 1.362 ms
Execution Time: 52.908 ms
```

New query output from `EXPLAIN ANALYZE`:
```
Limit  (cost=17650.94..17650.96 rows=10 width=187) (actual time=1.450..1.457 rows=10 loops=1)
--
CTE predecessor_receipts
->  Limit  (cost=17559.25..17559.27 rows=10 width=302) (actual time=0.489..0.497 rows=10 loops=1)
->  Sort  (cost=17559.25..17596.15 rows=14760 width=302) (actual time=0.489..0.495 rows=10 loops=1)
Sort Key: action_receipt_actions.receipt_included_in_block_timestamp DESC
Sort Method: top-N heapsort  Memory: 28kB
->  Index Scan using action_receipt_actions_receipt_predecessor_account_id_idx on action_receipt_actions  (cost=0.57..17240.29 rows=14760 width=302) (actual time=0.080..0.353 rows=84 loops=1)
Index Cond: (receipt_predecessor_account_id = 'andyh.near'::text)
CTE receiver_receipts
->  Limit  (cost=0.70..25.39 rows=10 width=302) (actual time=0.096..0.136 rows=10 loops=1)
->  Index Scan Backward using action_receipt_actions_receiver_and_timestamp_idx on action_receipt_actions action_receipt_actions_1  (cost=0.70..15694.87 rows=6357 width=302) (actual time=0.095..0.133 rows=10 loops=1)
Index Cond: (receipt_receiver_account_id = 'andyh.near'::text)
Filter: (receipt_predecessor_account_id <> 'system'::text)
Rows Removed by Filter: 3
CTE account_receipts
->  HashAggregate  (cost=0.95..1.15 rows=20 width=92) (actual time=0.807..0.823 rows=13 loops=1)
Group Key: predecessor_receipts.receipt_id, predecessor_receipts.action_index, predecessor_receipts.receipt_included_in_block_timestamp, predecessor_receipts.action_kind, predecessor_receipts.args
->  Append  (cost=0.00..0.70 rows=20 width=92) (actual time=0.491..0.667 rows=20 loops=1)
->  CTE Scan on predecessor_receipts  (cost=0.00..0.20 rows=10 width=92) (actual time=0.491..0.506 rows=10 loops=1)
->  CTE Scan on receiver_receipts  (cost=0.00..0.20 rows=10 width=92) (actual time=0.098..0.152 rows=10 loops=1)
->  Sort  (cost=65.13..65.18 rows=20 width=187) (actual time=1.449..1.451 rows=10 loops=1)
Sort Key: ar.receipt_included_in_block_timestamp DESC
Sort Method: quicksort  Memory: 29kB
->  Nested Loop  (cost=0.70..64.70 rows=20 width=187) (actual time=0.862..1.403 rows=13 loops=1)
->  CTE Scan on account_receipts ar  (cost=0.00..0.40 rows=20 width=92) (actual time=0.809..0.841 rows=13 loops=1)
->  Index Scan using receipts_pkey on receipts r  (cost=0.70..3.21 rows=1 width=171) (actual time=0.039..0.039 rows=1 loops=13)
Index Cond: (receipt_id = ar.receipt_id)
Planning Time: 1.479 ms
Execution Time: 1.737 ms
```

Network requests to mainnet contract helper:
![image](https://user-images.githubusercontent.com/36863574/164118579-49173745-a93b-4793-a076-a2d3c574b287.png)


Network requests to refactored contract helper running locally:
![image](https://user-images.githubusercontent.com/36863574/164118632-fc52071c-0c74-44d4-80db-091d04e83bf3.png)
