### PR TITLE
fix(indexer): restore limit parameter with cap

### DIFF
--- a/middleware/indexer.js
+++ b/middleware/indexer.js
@@ -53,6 +53,11 @@ const findStakingDeposits = async (ctx) => {
 const findAccountActivity = async (ctx) => {
     const { accountId } = ctx.params;
 
+    let { limit = 10 } = ctx.request.query;
+    if (limit > 100) {
+        limit = 100;
+    }
+
     const { rows } = await pool.query(
         `
         with predecessor_receipts as (
@@ -99,7 +104,7 @@ const findAccountActivity = async (ctx) => {
         order by ar.receipt_included_in_block_timestamp desc
         limit $2
         ;
-    `, [accountId, 10]);
+    `, [accountId, limit]);
 
     ctx.body = rows;
 };


### PR DESCRIPTION
This PR restores use of the `limit` query string parameter to the endpoint responsible for returning the list of recent transactions. I've added a cap of 100 on the returnable limit to ensure a reasonable amount of data is returned.

I have opted to leave the `offset` parameter out for now, as the responsibility for this endpoint should be fetching the most recent transactions. If pagination ends up being a requirement for non-wallet usage then we should look at designing a separate endpoint that can make this query in such a way that does not incur an unnecessary performance hit.