### PR TITLE
Temporarily disable recent activity endpoint

### DIFF
--- a/app.js
+++ b/app.js
@@ -160,7 +160,7 @@ const {
 } = require('./middleware/indexer');
 router.get('/publicKey/:publicKey/accounts', findAccountsByPublicKey);
 router.get('/staking-deposits/:accountId', findStakingDeposits);
-router.get('/account/:accountId/activity', findAccountActivity);
+router.get('/account/:accountId/activity', (ctx) => (ctx.body = []));
 router.get('/account/:accountId/callReceivers', findReceivers);
 router.get('/account/:accountId/likelyTokens', findLikelyTokens);
 router.get('/account/:accountId/likelyNFTs', findLikelyNFTs);


### PR DESCRIPTION
- Seems that SQL planner has decided this query should take way more effort to fulfill than it should -- temporarily disabling it for stability of the frontend