### PR TITLE
fix(indexer): restore original recent transactions query

### DIFF
--- a/middleware/indexer.js
+++ b/middleware/indexer.js
@@ -53,60 +53,37 @@ const findStakingDeposits = async (ctx) => {
 const findAccountActivity = async (ctx) => {
     const { accountId } = ctx.params;
 
-    let { limit = 10 } = ctx.request.query;
+    let { limit = 10, offset } = ctx.request.query;
     if (limit > 100) {
         limit = 100;
+    }
+    if (!offset) {
+        offset = '9999999999999999999';
     }
 
     const { rows } = await pool.query(
         `
-        with predecessor_receipts as (
-            select  receipt_id
-                ,   index_in_action_receipt as action_index
-                ,   receipt_included_in_block_timestamp
-                ,   action_kind
-                ,   args
-            from action_receipt_actions
-            where receipt_predecessor_account_id = $1
-            order by receipt_included_in_block_timestamp desc
-            limit $2
-        ), receiver_receipts as (
-            select  receipt_id
-                ,   index_in_action_receipt
-                ,   receipt_included_in_block_timestamp
-                ,   action_kind
-                ,   args
-            from action_receipt_actions
-            where receipt_receiver_account_id = $1
-                and receipt_predecessor_account_id != 'system'
-            order by receipt_included_in_block_timestamp desc
-            limit $2
-        ), account_receipts as (
-            select *
-            from predecessor_receipts
-
-            union
-
-            select *
-            from receiver_receipts
-        )
-        select  r.included_in_block_hash as block_hash
-            ,   r.included_in_block_timestamp as block_timestamp
-            ,   r.originated_from_transaction_hash as hash
-            ,   ar.action_index
-            ,   r.predecessor_account_id as signer_id
-            ,   r.receiver_account_id as receiver_id
-            ,   ar.action_kind
-            ,   ar.args
-        from account_receipts as ar
-        join receipts as r
-            on r.receipt_id = ar.receipt_id
-        order by ar.receipt_included_in_block_timestamp desc
-        limit $2
+        select
+            included_in_block_hash block_hash,
+            included_in_block_timestamp block_timestamp,
+            originated_from_transaction_hash hash,
+            index_in_action_receipt action_index,
+            predecessor_account_id signer_id,
+            receiver_account_id receiver_id,
+            action_kind,
+            args
+        from action_receipt_actions
+        join receipts using(receipt_id)
+        where
+            receipt_predecessor_account_id != 'system' and
+            (receipt_predecessor_account_id = $1 or receipt_receiver_account_id = $1) and
+            $2 > receipt_included_in_block_timestamp
+        order by receipt_included_in_block_timestamp desc
+        limit $3
         ;
-    `, [accountId, limit]);
+    `, [accountId, offset, limit + 100]);
 
-    ctx.body = rows;
+    ctx.body = rows.slice(0, limit);
 };
 
 const findAccountsByPublicKey = async (ctx) => {


### PR DESCRIPTION
This PR restores the recent transactions SQL query to the original implementation. When the endpoint responsible for making this query is re-enabled we will want to resume using the original query as the updated query continues to exhibit abysmal performance.

Note that the only change from the original implementation is the addition of a hard limit on the number of rows returned, which should preclude abuse of the endpoint.