### PR TITLE
WAL-309 Proxy indexer requests to indexer service

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -15,3 +15,4 @@ WALLET_URL=https://wallet.nearprotocol.com
 INDEXER_DB_CONNECTION=postgres://<user>:<password>@<domain>/near_indexer_for_wallet_testnet
 USE_MOCK_TWILIO=true
 NEARPAY_SECRET_KEY=your_secret_key # secret key used to create signatures for NearPay integration
+INDEXER_SERVICE_URL=

--- a/app.js
+++ b/app.js
@@ -157,9 +157,9 @@ router.get('/moonpay/signURL', moonpay.signURL);
 const nearpay = require('./middleware/nearpay');
 router.get('/nearpay/signParams', nearpay.signParams);
 
-const proxy = ({ host }) => async (ctx) => {
+const proxy = ({ host, timeout = 60000 }) => async (ctx) => {
     const url = new URL(ctx.url, host);
-    const response = await superagent(ctx.method, url);
+    const response = await superagent(ctx.method, url).timeout(timeout);
 
     ctx.body = response.body;
     ctx.status = response.status;


### PR DESCRIPTION
Forwards all indexer related requests to the new standalone indexer service.

⚠️ Indexer service actually needs to be live before we land this