### PR TITLE
fix(2fa): overwrite disabled 2FA records when changing type

### DIFF
--- a/middleware/2fa.js
+++ b/middleware/2fa.js
@@ -250,7 +250,6 @@ const initCode = async (ctx) => {
 
         await recoveryMethodService.updateTwoFactorRecoveryMethod({
             accountId,
-            // FIXME: Should this be escaped?
             detail,
             kind,
             requestId: -1,

--- a/services/recovery_method.js
+++ b/services/recovery_method.js
@@ -92,7 +92,7 @@ class RecoveryMethodService {
         });
     }
 
-    async updateTwoFactorRecoveryMethod({ accountId, requestId, securityCode }) {
+    async updateTwoFactorRecoveryMethod({ accountId, detail, kind, requestId, securityCode }) {
         const twoFactorRecoveryMethod = await this.getTwoFactorRecoveryMethod(accountId);
         if (!twoFactorRecoveryMethod) {
             return null;
@@ -100,10 +100,10 @@ class RecoveryMethodService {
 
         return this.db.updateRecoveryMethod({
             accountId,
-            kind: twoFactorRecoveryMethod.kind,
+            kind: kind || twoFactorRecoveryMethod.kind,
             publicKey: twoFactorRecoveryMethod.publicKey,
         }, {
-            detail: twoFactorRecoveryMethod.detail,
+            detail: detail || twoFactorRecoveryMethod.detail,
             requestId,
             securityCode,
         });

--- a/services/recovery_method.js
+++ b/services/recovery_method.js
@@ -98,6 +98,12 @@ class RecoveryMethodService {
             return null;
         }
 
+        // if the `kind` property is changing, then the previous recovery method record must
+        // be deleted since `kind` is part of the range key used to uniquely identify records
+        if (kind && twoFactorRecoveryMethod.kind !== kind) {
+            await this.deleteRecoveryMethod({ accountId, kind: twoFactorRecoveryMethod.kind });
+        }
+
         return this.db.updateRecoveryMethod({
             accountId,
             kind: kind || twoFactorRecoveryMethod.kind,

--- a/test/2fa.test.js
+++ b/test/2fa.test.js
@@ -127,6 +127,29 @@ describe('2fa method management', function () {
             expectJSONResponse(result);
             expect2faCodeSentResponse(result);
         });
+
+        it('replaces previous 2FA recovery method kinds', async () => {
+            await recoveryMethodService.deleteRecoveryMethod({ accountId, kind: TWO_FACTOR_AUTH_KINDS.EMAIL });
+
+            await testAccountHelper.init2faMethod({
+                accountId,
+                method: twoFactorMethods.phone,
+                bypassEndpointCreation: true,
+            });
+
+            let recoveryMethod = await recoveryMethodService.getTwoFactorRecoveryMethod(accountId);
+            expect(recoveryMethod.detail).equal(twoFactorMethods.phone.detail);
+            expect(recoveryMethod.kind).equal(TWO_FACTOR_AUTH_KINDS.PHONE);
+
+            await testAccountHelper.init2faMethod({
+                accountId,
+                method: twoFactorMethods.email,
+            });
+
+            recoveryMethod = await recoveryMethodService.getTwoFactorRecoveryMethod(accountId);
+            expect(recoveryMethod.detail).equal(twoFactorMethods.email.detail);
+            expect(recoveryMethod.kind).equal(TWO_FACTOR_AUTH_KINDS.EMAIL);
+        });
     });
 
     describe('completing an already requested 2fa method', () => {


### PR DESCRIPTION
This PR ensures that reenabling 2FA methods with a different `kind` and/or `detail` correctly overwrites the existing document to ensure that the new method is used. This is possible because the wallet frontend does not delete 2FA recovery method documents when they are disabled in the UI. As a result the old document still exists when 2FA is reenabled and is not updated correctly.

Fixes #612 
Likely fixes https://github.com/near/near-wallet/issues/2638