### PR TITLE
feat: Bypass account ownership check on ledger/seed phrase recovery creation for non-existent implicit accounts

### DIFF
--- a/app.js
+++ b/app.js
@@ -73,6 +73,7 @@ const {
     withNear,
     checkAccountOwnership,
     createCheckAccountDoesNotExistMiddleware,
+    accountAuthMiddleware,
 } = require('./middleware/near');
 
 app.use(withNear);
@@ -235,7 +236,7 @@ async function withPublicKey(ctx, next) {
 
 router.post(
     '/account/seedPhraseAdded',
-    checkAccountOwnership,
+    accountAuthMiddleware,
     withPublicKey,
     async (ctx) => {
         const { publicKey, request: { body: { accountId } } } = ctx;
@@ -251,7 +252,7 @@ router.post(
 
 router.post(
     '/account/ledgerKeyAdded',
-    checkAccountOwnership,
+    accountAuthMiddleware,
     withPublicKey,
     async (ctx) => {
         const { publicKey, request: { body: { accountId } } } = ctx;

--- a/middleware/near.js
+++ b/middleware/near.js
@@ -56,7 +56,7 @@ async function checkAccountOwnership(ctx, next) {
     return await next();
 }
 
-// TODO: near-api-js should have explicit accoutn existence check
+// TODO: near-api-js should have explicit account existence check
 async function getAccountExists(near, accountId) {
     try {
         await (await near.account(accountId)).state();


### PR DESCRIPTION
This PR bypasses the account ownership check on creation of recovery methods for ledger (`/account/ledgerKeyAdded`) and seed phrases (`/account/seedPhraseAdded`) if the account:
1. Does not exist on-chain
1. Has an implicit account ID

For named accounts which exist on-chain there is no change, if the named account does not exist the middleware will return `403`.

This change is to support creation of zero-balance ledger/seed phrase accounts.

---

- refactor(near): Extract account existence check to own function
- feat(account): Skip ownership check if implicit account doesnt exist
- test(account): Test account ownership skip for ledger/seed phrase
