### PR TITLE
(fix) Configure testnet new accounts to get 200N

### DIFF
--- a/ecs/contract-helper.container-definition.json
+++ b/ecs/contract-helper.container-definition.json
@@ -34,7 +34,7 @@
       },
       {
         "name": "NEW_ACCOUNT_AMOUNT",
-        "value": "10000000000000000000000000"
+        "value": "200000001000000000000000000"
       },
       {
         "name": "FUNDED_ACCOUNT_BALANCE",


### PR DESCRIPTION
Appears to be a regression from migration to ECS; new accounts are only getting 10N but have been getting 200N historically :)