### PR TITLE
Fix: set validators cache time to 1 hour

### DIFF
--- a/src/middleware/indexer.js
+++ b/src/middleware/indexer.js
@@ -236,7 +236,7 @@ const findLikelyNFTsFromBlock = async (ctx) => {
 
 
 // One hour cache window since validators do not change often
-const validatorCache = new Cache({ stdTTL: 60, checkperiod: 0, useClones: false });
+const validatorCache = new Cache({ stdTTL: 3600, checkperiod: 0, useClones: false });
 
 async function fetchAndCacheValidators(cache) {
     const { rows: validatorDetails } = await pool.query(`SELECT account_id FROM accounts WHERE account_id LIKE ANY(ARRAY${poolMatch})`);


### PR DESCRIPTION
According to the node-cache documentation: https://www.npmjs.com/package/node-cache

Current TTL time is set incorrectly (60 seconds instead of wanted 1 hour); This PR fixes this issues