### PR TITLE
feat: Add error listener to postgres pool

### DIFF
--- a/src/middleware/indexer.js
+++ b/src/middleware/indexer.js
@@ -12,6 +12,10 @@ const replicaConnections = JSON.parse(INDEXER_DB_REPLICAS);
 const indexerConnection = replicaConnections[(new Date()).valueOf() % replicaConnections.length];
 const pool = new Pool({ connectionString: indexerConnection, });
 
+pool.on('error', (err) => {
+    console.error('Postgres pool error: ', err);
+});
+
 const poolMatch = NEAR_WALLET_ENV.startsWith('mainnet')
     ? JSON.stringify(['%.poolv1.near', '%.pool.near']).replace(/"/g, '\'')
     : JSON.stringify(['%.pool.%.m0', '%.factory01.littlefarm.testnet', '%.factory.colorpalette.testnet']).replace(/"/g, '\'');


### PR DESCRIPTION
This PR adds an error listener to `pg.Pool` to avoid the error bubbling up and causing the node process to crash. The error is caught and logged. `Pool` should handle re-connection under the hood. 