### PR TITLE
fix: Dont run deployment pipeline from PRs

### DIFF
--- a/.github/workflows/deployment-pipeline.yml
+++ b/.github/workflows/deployment-pipeline.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - master
-  pull_request:
 
 concurrency:
   group: 'deployments'


### PR DESCRIPTION
`pull_request` trigger was left mistakenly left behind while testing the deployment pipeline 