### PR TITLE
ci: prevent subsequent merges cancelling in progress deployments

### DIFF
--- a/.github/workflows/deployment-pipeline.yml
+++ b/.github/workflows/deployment-pipeline.yml
@@ -7,7 +7,6 @@ on:
 
 concurrency:
   group: 'deployments'
-  cancel-in-progress: true
 
 jobs:
   checks:


### PR DESCRIPTION
The current behavior is to `cancel-in-progress` workflows when a new one starts. This could potentially leave our infrastructure in a bad state as the job would only be partially finished.

This PR removes the cancel behavior making deployments run serially, allowing them to complete before the next is triggered. This does cause delays if we are merging PRs in quick succession, but as that is rare in the repository it shouldn't cause any problems.