### PR TITLE
feat: configurable dynamodb-local instance

### DIFF
--- a/local_dynamo.js
+++ b/local_dynamo.js
@@ -8,13 +8,14 @@ const EmailDomainBlacklist = require('./src/db/schemas/email_domain_blacklist');
 const IdentityVerificationMethod = require('./src/db/schemas/identity_verification_method');
 const RecoveryMethod = require('./src/db/schemas/recovery_method');
 
-const LOCAL_DYNAMODB_PORT = 7877;
-const TEST_DYNAMODB_PORT = 7879;
+const LOCAL_DYNAMODB_HOST = process.env.LOCAL_DYNAMODB_HOST || 'localhost';
+const LOCAL_DYNAMODB_PORT = process.env.LOCAL_DYNAMODB_PORT || 7877;
+const TEST_DYNAMODB_PORT = process.env.TEST_DYNAMODB_PORT || 7879;
 
 function overrideLocalDynamo({ port } = { port: LOCAL_DYNAMODB_PORT }) {
     dynamo.documentClient(new DocumentClient({
         convertEmptyValues: true,
-        endpoint: `localhost:${port}`,
+        endpoint: `${LOCAL_DYNAMODB_HOST}:${port}`,
         sslEnabled: false,
         region: 'local-env'
     }));

--- a/scripts/create-dynamodb-tables.js
+++ b/scripts/create-dynamodb-tables.js
@@ -1,0 +1,9 @@
+/*
+* This is intended for use upon starting a local DynamoDB Docker container only
+* `run-development-dynamodb.js` should be used to start a local instance process
+* */
+const { createTables } = require('../local_dynamo');
+
+(async function () {
+    await createTables();
+}());


### PR DESCRIPTION
This PR makes it possible to override the hardcoded host/ports for the local/test DynamoDB instance using environment variables. The defaults will continue to reference the original hardcoded values.