### PR TITLE
fix: external local dynamo init

### DIFF
--- a/scripts/create-dynamodb-tables.js
+++ b/scripts/create-dynamodb-tables.js
@@ -2,8 +2,9 @@
 * This is intended for use upon starting a local DynamoDB Docker container only
 * `run-development-dynamodb.js` should be used to start a local instance process
 * */
-const { createTables } = require('../local_dynamo');
+const { createTables, overrideLocalDynamo } = require('../local_dynamo');
 
 (async function () {
+    overrideLocalDynamo();
     await createTables();
 }());


### PR DESCRIPTION
This PR configures the local DynamoDB environment prior to table initialization.