### PR TITLE
fix: remove reference to assets__fungible_token_events

### DIFF
--- a/src/middleware/indexer.js
+++ b/src/middleware/indexer.js
@@ -156,15 +156,7 @@ const likelyTokensFromBlock = async ({ fromBlockTimestamp, accountId }) => {
             and receipt_included_in_block_timestamp > $4
     `;
 
-    const ownershipChangeEvents = `
-        select distinct emitted_by_contract_account_id as receiver_account_id 
-        from assets__fungible_token_events
-        where token_new_owner_account_id = $1
-            and emitted_at_block_timestamp <= $3
-            and emitted_at_block_timestamp > $4
-    `;
-
-    const { rows } = await pool.query([received, mintedWithBridge, calledByUser, ownershipChangeEvents].join(' union '), [accountId, BRIDGE_TOKEN_FACTORY_ACCOUNT_ID, lastBlockTimestamp, fromBlockTimestamp]);
+    const { rows } = await pool.query([received, mintedWithBridge, calledByUser].join(' union '), [accountId, BRIDGE_TOKEN_FACTORY_ACCOUNT_ID, lastBlockTimestamp, fromBlockTimestamp]);
     return { rows, lastBlockTimestamp };
 };
 


### PR DESCRIPTION
This PR removes a reference from the indexer queries to a soon-to-be-deprecated table (`assets__fungible_token_events`). As this table will be removed entirely on March 1st 2023, it must be removed from Contract Helper to prevent queries from breaking.

This table is only referenced from within a subquery used to find fungible tokens. Removing this query will reduce the efficacy/reliability of fungible tokens query, in particular those FTs for which the only record of ownership is a transfer of ownership from another account.

https://github.com/near/near-indexer-for-explorer/discussions/351