### PR TITLE
Migrate findAccountsByPublicKey endpoint to QueryAPI

### DIFF
--- a/src/middleware/indexer.js
+++ b/src/middleware/indexer.js
@@ -134,7 +134,7 @@ const findAccountsByPublicKey = async (ctx) => {
                     query: `
                         query access_keys_v1_by_public_key {
                             dataplatform_near_access_keys_v1_access_keys_v1(
-                            where: {public_key: {_eq: \"${publicKey}\"}}
+                            where: {public_key: {_eq: "${publicKey}"}}
                             ) {
                             account_id
                             }

--- a/src/middleware/indexer.js
+++ b/src/middleware/indexer.js
@@ -1,9 +1,11 @@
 const { Pool } = require('pg');
 const Cache = require('node-cache');
 const bunyan = require('bunyan');
+const fetch = require('node-fetch');
 
 const {
     BRIDGE_TOKEN_FACTORY_ACCOUNT_ID = 'factory.bridge.near',
+    GRAPHQL_URL = 'https://near-queryapi.api.pagoda.co/v1/graphql',
     NEAR_WALLET_ENV,
     // INDEXER_DB_CONNECTION,
     INDEXER_DB_REPLICAS,
@@ -119,15 +121,30 @@ const findAccountActivity = async (ctx) => {
 const findAccountsByPublicKey = async (ctx) => {
     try {
         const { publicKey } = ctx.params;
-        const { rows } = await pool.query(`
-        SELECT DISTINCT account_id
-        FROM access_keys
-        JOIN accounts USING (account_id)
-        WHERE public_key = $1
-            AND accounts.deleted_by_receipt_id IS NULL
-            AND access_keys.deleted_by_receipt_id IS NULL
-    `, [publicKey]);
-        ctx.body = rows.map(({ account_id }) => account_id);
+
+        const response = await fetch(GRAPHQL_URL, {
+            method: 'POST',
+            headers: {
+                'content-type': 'application/json',
+                'x-hasura-role': 'dataplatform_near'
+            },
+            body: JSON.stringify({
+                query: `
+                    query access_keys_v1_by_public_key {
+                        dataplatform_near_access_keys_v1_access_keys_v1(
+                        where: {public_key: {_eq: \"${publicKey}\"}}
+                        ) {
+                        account_id
+                        }
+                    }
+                `,
+                operationName: 'access_keys_v1_by_public_key'
+            }),
+        });
+
+        const respJson = await response.json();
+        const rows = respJson.data.dataplatform_near_access_keys_v1_access_keys_v1;
+        ctx.body = rows.map(item => item.account_id);
     } catch (e) {
         if (ctx.log && typeof ctx.log.error === 'function') {
             ctx.log.error(e);


### PR DESCRIPTION
Closes https://github.com/near/near-contract-helper/issues/684

Related to https://github.com/near/queryapi/issues/325

The response continues the same using QueryAPI

```
curl -XGET http://localhost:3050/publicKey/ed25519:FXFhPD2aYw6YZB9pa9UYJNkJgKGuWDsJvDH13B5NjehL/accounts
```
QueryAPI response:
![Screenshot 2024-04-17 at 2 39 43 PM](https://github.com/near/near-contract-helper/assets/11862123/e2590e68-2b86-498e-8831-e7f333d80708)

Explorer DB record:
![Screenshot 2024-04-17 at 2 41 47 PM](https://github.com/near/near-contract-helper/assets/11862123/52d6abab-08ba-462a-a7df-423d4675e434)
